### PR TITLE
fix: chunk oversized IN queries at Firestore's 30-value cap

### DIFF
--- a/src/firebase-adapter.ts
+++ b/src/firebase-adapter.ts
@@ -43,6 +43,37 @@ type WhereCondition = {
 	connector?: "AND" | "OR";
 };
 
+/**
+ * Firestore caps the `IN` operator at 30 comparison values. When a `where`
+ * clause passes more than this, queries throw with
+ * `INVALID_ARGUMENT: 'IN' supports up to 30 comparison values.`
+ * We split oversized IN values into chunks of this size in both `deleteMany`
+ * and the regular `findMany` path and merge results.
+ * https://firebase.google.com/docs/firestore/query-data/queries#query_limitations
+ */
+const FIRESTORE_IN_CHUNK_SIZE = 30;
+
+type OversizedInClause = WhereCondition & {
+	operator: "in";
+	value: readonly unknown[];
+};
+
+/**
+ * Narrows a where clause to an `in` condition whose value array exceeds
+ * Firestore's 30-value cap. Used by `deleteMany` and `findMany` to trigger
+ * chunked sub-queries.
+ */
+function findOversizedInClause(
+	where: WhereCondition[] | undefined,
+): OversizedInClause | undefined {
+	return (where ?? []).find(
+		(w): w is OversizedInClause =>
+			w.operator === "in" &&
+			Array.isArray(w.value) &&
+			w.value.length > FIRESTORE_IN_CHUNK_SIZE,
+	);
+}
+
 function resolveDb(config?: FirestoreAdapterConfig | Firestore): Firestore {
 	if (!config) return initFirestore();
 	if ((config as Firestore).collection) return config as Firestore;
@@ -493,6 +524,36 @@ export const firestoreAdapter: (
 				},
 				deleteMany: async ({ model, where }) => {
 					const col = getCollectionRef(db, model, collections);
+					// Firestore's `IN` operator caps at 30 values. If a single where
+					// clause carries more than 30 values, split into sub-queries and
+					// sum the deletes so callers (e.g. better-auth's multi-session
+					// `deleteSessions(tokens)`) don't blow up once they cross the cap.
+					const oversized = findOversizedInClause(where);
+					if (oversized) {
+						let total = 0;
+						for (
+							let i = 0;
+							i < oversized.value.length;
+							i += FIRESTORE_IN_CHUNK_SIZE
+						) {
+							const chunk = oversized.value.slice(
+								i,
+								i + FIRESTORE_IN_CHUNK_SIZE,
+							);
+							const chunkedWhere = (where as WhereCondition[]).map((w) =>
+								w === oversized
+									? { ...w, value: chunk as WhereCondition["value"] }
+									: w,
+							);
+							const cq = applyWhereClause(col, chunkedWhere, mapper);
+							const csnap = await cq.get();
+							for (const d of csnap.docs) {
+								await d.ref.delete();
+								total++;
+							}
+						}
+						return total;
+					}
 					const q = applyWhereClause(col, where, mapper);
 					const snap = await q.get();
 					let count = 0;
@@ -958,6 +1019,64 @@ export const firestoreAdapter: (
 						if (offset) results = results.slice(offset);
 						if (limit) results = results.slice(0, limit);
 
+						return results as any[];
+					}
+
+					// Firestore's `IN` operator caps at 30 values. If a simple non-ID
+					// `in` query carries more than 30 values, split into chunks and
+					// merge the results. Any post-filter sort / offset / limit is
+					// re-applied after the merge to preserve the caller-visible
+					// ordering and pagination.
+					const oversizedIn = findOversizedInClause(where);
+					if (oversizedIn) {
+						const merged = new Map<string, any>();
+						for (
+							let i = 0;
+							i < oversizedIn.value.length;
+							i += FIRESTORE_IN_CHUNK_SIZE
+						) {
+							const chunk = oversizedIn.value.slice(
+								i,
+								i + FIRESTORE_IN_CHUNK_SIZE,
+							);
+							const chunkedWhere = (where as WhereCondition[]).map((w) =>
+								w === oversizedIn
+									? { ...w, value: chunk as WhereCondition["value"] }
+									: w,
+							);
+							let cq: FirebaseFirestore.Query = applyWhereClause(
+								col,
+								chunkedWhere,
+								mapper,
+							);
+							if (sortBy?.field) {
+								const fieldName = mapper.toDb(sortBy.field);
+								const direction = sortBy.direction === "desc" ? "desc" : "asc";
+								cq = cq.orderBy(fieldName, direction);
+							}
+							const csnap = await cq.get();
+							for (const d of csnap.docs) {
+								const data = d.data();
+								const result: Record<string, any> = { id: d.id };
+								for (const [k, v] of Object.entries(data)) {
+									result[mapper.fromDb(k)] = convertTimestamp(v);
+								}
+								merged.set(d.id, result);
+							}
+						}
+						let results = Array.from(merged.values());
+						if (sortBy?.field) {
+							results.sort((a, b) => {
+								const aVal = a[sortBy.field];
+								const bVal = b[sortBy.field];
+								const dir = sortBy.direction === "desc" ? -1 : 1;
+								if (aVal < bVal) return -1 * dir;
+								if (aVal > bVal) return 1 * dir;
+								return 0;
+							});
+						}
+						if (offset) results = results.slice(offset);
+						if (limit) results = results.slice(0, limit);
 						return results as any[];
 					}
 


### PR DESCRIPTION
## Context

Firestore rejects `where(field, \"in\", [...])` queries carrying more than 30 values:

```
INVALID_ARGUMENT: 'IN' supports up to 30 comparison values.
```

[docs](https://firebase.google.com/docs/firestore/query-data/queries#query_limitations).

Today both `deleteMany` and the regular (non-ID) `findMany` path forward the caller's value array directly to `.where(field, \"in\", value)`, so any caller that passes more than 30 values in a single `IN` clause throws.

## Where this bites in practice

This isn't a theoretical edge case. Better Auth's `multi-session` plugin sizes its DB calls by \"number of `_multi-*` cookies on the browser\":

- **Sign-in** hook ([plugins/multi-session/index.mjs#L127-L140](https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/plugins/multi-session/index.ts)) collects all `_multi-*` cookies, filters to same-user sessions, and calls `internalAdapter.deleteSessions(tokens)` — which lowers to `deleteMany({ where: [{ field: 'token', operator: 'in', value: [...allMatchingTokens] }] })`.
- **list-device-sessions** endpoint calls `internalAdapter.findSessions(tokens)` with every verified multi-session cookie token — same shape, now through `findMany`.

A browser that accumulates 30+ multi-session cookies (easy during dev, possible in production with heavy account switching — they only get expired when the plugin cleans up, which itself requires a same-user match) crashes **every** sign-in with the INVALID_ARGUMENT error. The user sees a 500; the stack trace points at gRPC with no hint that the trigger is cookie accumulation. I hit this in production with 38 multi-session cookies after several months of testing.

Repro:

```ts
// With 31+ multi-session cookies on the browser, any sign-in response
// triggers the post-sign-in hook which calls:
await adapter.deleteMany({
  model: 'session',
  where: [{ field: 'token', operator: 'in', value: [/* 31+ tokens */] }],
});
// -> throws: 3 INVALID_ARGUMENT: 'IN' supports up to 30 comparison values.
```

## Fix

If a `where` clause contains an `in` condition whose value array exceeds 30, split it into 30-sized chunks and run the adapter method per chunk:

- **`deleteMany`** sums the per-chunk delete counts.
- **`findMany` (regular path)** dedupes merged results by document id and re-applies any `sortBy` / `offset` / `limit` after the merge, so caller-visible ordering and pagination are preserved.

Callers with ≤30 values in their `IN` hit the unchanged code path — zero behavior change for the common case.

A small helper `findOversizedInClause` isolates the detection logic and uses a user-defined type guard so the chunk loop can iterate the value array without any `as any` casts beyond the one required to fit back into the canonical `Where[\"value\"]` union when writing the chunked clause.

The ID-based `findMany` path already sidesteps `IN` (it uses `Promise.all(col.doc(id).get())` for each id) so it didn't need touching.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean
- [x] Ran the unpatched adapter locally against 38-element `IN`, reproduced the `INVALID_ARGUMENT` error, applied the patch, confirmed `deleteMany` and `findMany` both succeed and return the correct merged data.
- [ ] I'd be happy to add an integration test against the Firestore emulator if helpful — didn't include one to keep this PR minimal and because the existing `tests/index.test.ts` harness doesn't exercise `deleteMany` with `IN` yet. Let me know if you'd like me to add one.

## Out of scope

- `count` with oversized `IN` — same library has the same shape in `count`, but no Better Auth caller I'm aware of hits it. Happy to extend this PR if you'd like coverage there too.
- Updating `applyOperator` directly — the chunking has to happen at the method level since it requires running N queries, not transforming a single `Query` object.

I'm currently running a local [pnpm patch](https://pnpm.io/cli/patch) in my project with this exact change (applied to the `dist` files); happy to share that patch if it helps you review. Thanks for the library!