### PR TITLE
fix: strip undefined fields from Firestore write payloads

### DIFF
--- a/src/firebase-adapter.ts
+++ b/src/firebase-adapter.ts
@@ -289,6 +289,41 @@ function normalizeWriteData(model: string, data: Record<string, any>): Record<st
 	return normalizeSessionWriteData(data);
 }
 
+/**
+ * Build a Firestore-safe write payload from a normalized data object.
+ *
+ * - Maps app field names to their Firestore-side names via `mapper`.
+ * - Skips `undefined` values. The Firestore Admin SDK rejects writes that
+ *   contain `undefined` unless the client was initialized with
+ *   `ignoreUndefinedProperties: true`, and better-auth routinely emits
+ *   optional-undefined fields (e.g. `image` on email/password sign-up).
+ *   Stripping here lets the adapter work with any user-supplied Firestore
+ *   instance, not just ones we initialize.
+ * - Routes a string `id` field out as `idOverride` so create callers can
+ *   set it on the document reference instead of writing it into the body.
+ *   For updates the caller can simply ignore `idOverride` — you cannot
+ *   change a Firestore document ID by writing to a field.
+ *
+ * `null` is preserved deliberately: Firestore accepts null and callers may
+ * use it to explicitly clear a field.
+ */
+function buildFirestoreWriteData(
+	data: Record<string, any>,
+	mapper: FieldMapper,
+): { docData: Record<string, any>; idOverride: string | undefined } {
+	const docData: Record<string, any> = {};
+	let idOverride: string | undefined;
+	for (const [k, v] of Object.entries(data)) {
+		if (v === undefined) continue;
+		if (k === "id") {
+			if (typeof v === "string" && v) idOverride = v;
+			continue;
+		}
+		docData[mapper.toDb(k)] = v;
+	}
+	return { docData, idOverride };
+}
+
 export interface FirestoreAdapterOptions
 	extends Omit<FirestoreAdapterConfig, "firestore"> {
 	firestore?: Firestore;
@@ -330,16 +365,12 @@ export const firestoreAdapter: (
 					const txAdapter = {
 						create: async ({ model, data }: any) => {
 							const col = getCollectionRef(db, model, collections);
-							let ref = col.doc();
 							const normalizedData = normalizeWriteData(model, data);
-							const docData: any = {};
-							for (const [k, v] of Object.entries(normalizedData)) {
-								if (k === "id" && v) {
-									ref = col.doc(v as string);
-									continue;
-								}
-								docData[mapper.toDb(k)] = v;
-							}
+							const { docData, idOverride } = buildFirestoreWriteData(
+								normalizedData,
+								mapper,
+							);
+							const ref = idOverride ? col.doc(idOverride) : col.doc();
 							transaction.set(ref, docData);
 							return { ...normalizedData, id: ref.id };
 						},
@@ -354,10 +385,10 @@ export const firestoreAdapter: (
 							}
 							if (!doc) return null;
 							const normalizedUpdate = normalizeWriteData(model, update);
-							const updateData: any = {};
-							for (const [k, v] of Object.entries(normalizedUpdate)) {
-								updateData[mapper.toDb(k)] = v;
-							}
+							const { docData: updateData } = buildFirestoreWriteData(
+								normalizedUpdate,
+								mapper,
+							);
 							transaction.update(doc.ref, updateData);
 							const existing = doc.data();
 							const result: any = { id: doc.id };
@@ -395,19 +426,15 @@ export const firestoreAdapter: (
 			return {
 				create: async ({ model, data }) => {
 					const col = getCollectionRef(db, model, collections);
-					let ref = col.doc();
 					const normalizedData = normalizeWriteData(
 						model,
 						data as Record<string, any>,
 					);
-					const docData: any = {};
-					for (const [k, v] of Object.entries(normalizedData)) {
-						if (k === "id" && v) {
-							ref = col.doc(v as string);
-							continue;
-						}
-						docData[mapper.toDb(k)] = v;
-					}
+					const { docData, idOverride } = buildFirestoreWriteData(
+						normalizedData,
+						mapper,
+					);
+					const ref = idOverride ? col.doc(idOverride) : col.doc();
 					if (debugLogs) {
 						console.log(`[Firestore Adapter] CREATE ${model}:`, {
 							input: data,
@@ -491,12 +518,10 @@ export const firestoreAdapter: (
 							return null as any;
 						}
 
-						const updateData: any = {};
-						for (const [k, v] of Object.entries(
+						const { docData: updateData } = buildFirestoreWriteData(
 							normalizedUpdate as Record<string, any>,
-						)) {
-							updateData[mapper.toDb(k)] = v;
-						}
+							mapper,
+						);
 						if (debugLogs) {
 							console.log(
 								`[Firestore Adapter] UPDATE ${model} - updateData:`,
@@ -545,12 +570,10 @@ export const firestoreAdapter: (
 						return null as any;
 					}
 
-					const updateData: any = {};
-					for (const [k, v] of Object.entries(
+					const { docData: updateData } = buildFirestoreWriteData(
 						normalizedUpdate as Record<string, any>,
-					)) {
-						updateData[mapper.toDb(k)] = v;
-					}
+						mapper,
+					);
 					if (debugLogs) {
 						console.log(
 							`[Firestore Adapter] UPDATE ${model} - updateData:`,
@@ -583,10 +606,10 @@ export const firestoreAdapter: (
 						model,
 						update as Record<string, any>,
 					);
-					const updateData: any = {};
-					for (const [k, v] of Object.entries(normalizedUpdate)) {
-						updateData[mapper.toDb(k)] = v;
-					}
+					const { docData: updateData } = buildFirestoreWriteData(
+						normalizedUpdate,
+						mapper,
+					);
 					for (const whereClause of getChunkedWhereClauses(where)) {
 						const q = applyWhereClause(col, whereClause, mapper);
 						const snap = await q.get();

--- a/tests/helpers/firestore-secondary-storage.ts
+++ b/tests/helpers/firestore-secondary-storage.ts
@@ -1,0 +1,41 @@
+import { type Firestore, Timestamp } from "firebase-admin/firestore";
+
+/**
+ * Firestore-backed secondaryStorage adapter for better-auth.
+ *
+ * Intended for tests and examples only — not recommended for production.
+ * The point of secondaryStorage is to offload hot data from the primary DB
+ * to a fast K/V store. Reusing Firestore defeats that.
+ */
+export function firestoreSecondaryStorage(
+	db: Firestore,
+	collection = "_kv",
+) {
+	const col = db.collection(collection);
+	return {
+		get: async (key: string): Promise<string | null> => {
+			const snap = await col.doc(key).get();
+			if (!snap.exists) return null;
+			const data = snap.data() as
+				| { value: string; expiresAt: Timestamp | null }
+				| undefined;
+			if (!data) return null;
+			if (data.expiresAt && data.expiresAt.toMillis() < Date.now()) {
+				await snap.ref.delete();
+				return null;
+			}
+			return data.value;
+		},
+		set: async (key: string, value: string, ttl?: number) => {
+			await col.doc(key).set({
+				value,
+				expiresAt: ttl
+					? Timestamp.fromMillis(Date.now() + ttl * 1000)
+					: null,
+			});
+		},
+		delete: async (key: string) => {
+			await col.doc(key).delete();
+		},
+	};
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -200,6 +200,44 @@ describe.each<TestConfig>(
 		expect(remainingAfterDelete).toBe(34);
 	});
 
+	it("drops undefined fields on create and update without erroring", async () => {
+		// Firestore's Admin SDK rejects writes containing `undefined` unless
+		// `ignoreUndefinedProperties: true` is set on the client. better-auth
+		// routinely emits optional-undefined fields (e.g. `image` on
+		// email/password sign-up); the adapter must strip them so the write
+		// goes through cleanly with any user-supplied Firestore instance.
+		const adapter = getAdapter() as any;
+
+		// Note: better-auth's adapter wrapper strips client-supplied `id` and
+		// generates its own, so we don't pass one here.
+		const created = await adapter.create({
+			model: "user",
+			data: {
+				email: "undef@example.com",
+				name: "Undef",
+				image: undefined,
+			},
+		});
+		expect(created.id).toBeTruthy();
+
+		const found = await adapter.findOne({
+			model: "user",
+			where: [{ field: "id", operator: "eq", value: created.id }],
+		});
+		expect(found).toBeTruthy();
+		expect(found.email).toBe("undef@example.com");
+		// undefined fields should not have been persisted
+		expect(found.image).toBeUndefined();
+
+		const updated = await adapter.update({
+			model: "user",
+			where: [{ field: "id", operator: "eq", value: created.id }],
+			update: { name: "Undef2", image: undefined },
+		});
+		expect(updated).toBeTruthy();
+		expect(updated.name).toBe("Undef2");
+	});
+
 	it("coerces session foreign keys to scalar ids on create", async () => {
 		const adapter = getAdapter() as any;
 		const userRef = db.collection(cfg.collections.users).doc("session_user_fk");

--- a/tests/secondary-storage.test.ts
+++ b/tests/secondary-storage.test.ts
@@ -1,0 +1,71 @@
+import { betterAuth } from "better-auth";
+import type { Firestore } from "firebase-admin/firestore";
+import { firestoreAdapter } from "../src";
+import { initFirestore } from "../src/firestore";
+import { firestoreSecondaryStorage } from "./helpers/firestore-secondary-storage";
+
+const COLLECTIONS = {
+	users: "ss_users",
+	sessions: "ss_sessions",
+	accounts: "ss_accounts",
+	verificationTokens: "ss_verifications",
+	kv: "ss_kv",
+};
+
+async function clearAll(db: Firestore) {
+	for (const name of Object.values(COLLECTIONS)) {
+		const snap = await db.collection(name).get();
+		await Promise.all(snap.docs.map((d) => d.ref.delete()));
+	}
+}
+
+describe("better-auth with Firestore secondaryStorage (repro for #24)", () => {
+	const db = initFirestore({ name: "test-ss", projectId: "test" });
+
+	const auth = betterAuth({
+		database: firestoreAdapter({
+			firestore: db,
+			collections: {
+				users: COLLECTIONS.users,
+				sessions: COLLECTIONS.sessions,
+				accounts: COLLECTIONS.accounts,
+				verificationTokens: COLLECTIONS.verificationTokens,
+			},
+		}),
+		secondaryStorage: firestoreSecondaryStorage(db, COLLECTIONS.kv),
+		emailAndPassword: { enabled: true },
+		secret: "test-secret-not-for-prod",
+		baseURL: "http://localhost",
+	});
+
+	afterEach(async () => {
+		await clearAll(db);
+	});
+
+	// `it.fails` until #24 is resolved: today better-auth's signUpEmail calls
+	// `createSession` (which does a `findOne` read) inside the same transaction
+	// where `create(user)` has already done a `transaction.set` — Firestore
+	// rejects with "transactions require all reads to be executed before all
+	// writes." When the tx wrapper is refactored to buffer writes and overlay
+	// reads, this test will start passing and `it.fails` will itself fail,
+	// signaling that the modifier should be removed.
+	it.fails(
+		"signs up and signs in without violating Firestore txn read-before-write",
+		async () => {
+			const email = `u-${Date.now()}@example.com`;
+			const password = "password1234";
+
+			const signUp = await auth.api.signUpEmail({
+				body: { email, password, name: "Repro User" },
+				asResponse: true,
+			});
+			expect(signUp.status).toBe(200);
+
+			const signIn = await auth.api.signInEmail({
+				body: { email, password },
+				asResponse: true,
+			});
+			expect(signIn.status).toBe(200);
+		},
+	);
+});


### PR DESCRIPTION
## Summary

Firestore's Admin SDK rejects writes containing `undefined` unless the client was initialized with `ignoreUndefinedProperties: true`. better-auth routinely emits optional-undefined fields — e.g. `image` on email/password sign-up — and the adapter was passing them through to `transaction.set` / `docRef.set` / `docRef.update` as-is.

Until now the adapter's test suite only exercised `adapter.create` with hand-constructed minimal payloads (no `undefined` fields), so the bug was latent. It surfaces the moment a real better-auth flow — `signUpEmail`, in particular — runs through the adapter:

```
ERROR [Better Auth]: Failed to create user
Error: Value for argument "data" is not a valid Firestore document.
Cannot use "undefined" as a Firestore value (found in field "image").
    at Transaction.set (.../transaction.js:218:30)
    at Object.create (src/firebase-adapter.ts:343:20)
```

## Fix

Introduces a single `buildFirestoreWriteData(data, mapper)` helper that:

- maps app field names → Firestore field names via the existing `mapper`,
- **drops `undefined` values** (preserves `null` — Firestore accepts it and callers may use it to explicitly clear a field),
- routes a string `id` out as `idOverride` so `create` callers can set it on the document reference instead of writing it into the body (and so `update` callers can safely ignore it — you cannot change a Firestore document ID by writing to a field).

The helper backs **all six write sites**: transaction + non-transaction versions of `create`, `update`, and `updateMany`. Six previously-duplicated inline loops are now one helper.

## Tests

- **Direct regression test** in `tests/index.test.ts` (`drops undefined fields on create and update without erroring`), runs in both `snake_case` and `default` naming modes. Locks this bug down so it can't return silently.
- **secondaryStorage integration test** in `tests/secondary-storage.test.ts` + helper in `tests/helpers/firestore-secondary-storage.ts`. Marked `it.fails` — it serves as a tripwire for the **separate** issue #24 (\"Firestore transactions require all reads to be executed before all writes\"). Once the undefined fix lets the sign-up flow reach the second adapter call inside the transaction, Firestore's read-after-write constraint trips. When #24 is fixed, the test starts passing and `it.fails` itself fails, prompting removal of the modifier.

## Test results

```
Test Files  2 passed (2)
     Tests  14 passed | 1 expected fail (15)
```

All existing tests (12) still pass. New regression test passes in both naming modes (2). The `it.fails` repro correctly throws the #24 error (1 expected fail).

## What's still open

Issue #24 — the transaction read-before-write rule — is **not** addressed here. Fixing it cleanly requires re-architecting the tx adapter to buffer writes during the `run(...)` callback and overlay reads against the buffer, then flush at commit. That's meaningful enough to deserve its own PR; this one stays focused on the undefined-field bug.