### PR TITLE
fix: buffer writes inside Firestore transactions to satisfy read-before-write (closes #24)

### DIFF
--- a/src/firebase-adapter.ts
+++ b/src/firebase-adapter.ts
@@ -324,6 +324,246 @@ function buildFirestoreWriteData(
 	return { docData, idOverride };
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Transaction write buffer (per-transaction)
+// ─────────────────────────────────────────────────────────────────────────────
+// Firestore requires every `transaction.get` to complete before any
+// `transaction.set` / `update` / `delete`. Better-auth interleaves them
+// freely — a typical sign-up runs `create(user)` → `findOne(session)` →
+// `create(session)` inside one transaction. We satisfy Firestore's rule by
+// deferring every staged write until after the user callback resolves;
+// reads in the meantime overlay matching buffered docs so the callback
+// observes its own writes (transactional read-your-writes semantics).
+//
+// Operations also merge in place: `create` + `update` on the same ref
+// collapses to a single `set` at flush time, and `update` + `update`
+// collapses to a single merged `update`. The buffer is constructed inside
+// `runTransaction`, so Firestore's automatic retries on contention get a
+// fresh buffer each pass.
+//
+// Read overlay is best-effort: `matchesWhere` covers the operators
+// better-auth uses inside transactions (eq, ne, in, notIn, gt(e), lt(e),
+// contains, startsWith, endsWith, plus AND/OR connectors). Exotic
+// operators fall through to a real `transaction.get`, which won't see
+// buffered docs of the same model — in practice better-auth never
+// generates such clauses inside its tx callbacks.
+
+type TxBufferOp = "create" | "update";
+
+interface TxBufferEntry {
+	op: TxBufferOp;
+	model: string;
+	ref: FirebaseFirestore.DocumentReference;
+	/**
+	 * Payload for flushing: full doc body (create) or update mask (update).
+	 * Keys are db-side field names — ready to hand straight to
+	 * `transaction.set` / `transaction.update`.
+	 */
+	docData: Record<string, any>;
+	/**
+	 * Full app-visible representation of the doc including `id`. Keys are
+	 * canonical app-side field names. Used to overlay subsequent reads.
+	 */
+	appData: Record<string, any>;
+}
+
+class TxBuffer {
+	private byPath = new Map<string, TxBufferEntry>();
+
+	/** Stage a create. Returns the entry so the caller can read back `appData.id`. */
+	stageCreate(
+		model: string,
+		ref: FirebaseFirestore.DocumentReference,
+		docData: Record<string, any>,
+		appNormalized: Record<string, any>,
+	): TxBufferEntry {
+		const entry: TxBufferEntry = {
+			op: "create",
+			model,
+			ref,
+			docData: { ...docData },
+			appData: { ...appNormalized, id: ref.id },
+		};
+		this.byPath.set(ref.path, entry);
+		return entry;
+	}
+
+	/**
+	 * Stage an update on `ref`. If a prior entry exists for the same ref —
+	 * regardless of whether it was a create or update — merge in place so
+	 * the flush emits one combined write. `baseAppData` provides the
+	 * pre-update fields needed to build a full app-visible state for
+	 * subsequent read overlays.
+	 */
+	stageUpdate(
+		model: string,
+		ref: FirebaseFirestore.DocumentReference,
+		updateDocData: Record<string, any>,
+		updateAppData: Record<string, any>,
+		baseAppData: Record<string, any>,
+	): TxBufferEntry {
+		const existing = this.byPath.get(ref.path);
+		if (existing) {
+			Object.assign(existing.docData, updateDocData);
+			Object.assign(existing.appData, updateAppData);
+			return existing;
+		}
+		const entry: TxBufferEntry = {
+			op: "update",
+			model,
+			ref,
+			docData: { ...updateDocData },
+			appData: { ...baseAppData, ...updateAppData, id: ref.id },
+		};
+		this.byPath.set(ref.path, entry);
+		return entry;
+	}
+
+	/** First buffered create for `model` whose appData satisfies `where`. */
+	findCreateMatching(
+		model: string,
+		where: WhereCondition[] | undefined,
+	): TxBufferEntry | undefined {
+		for (const entry of this.byPath.values()) {
+			if (entry.op !== "create" || entry.model !== model) continue;
+			if (matchesWhere(entry.appData, where)) return entry;
+		}
+		return undefined;
+	}
+
+	/** Buffered entry (create or update) for a specific ref path, if any. */
+	getByPath(refPath: string): TxBufferEntry | undefined {
+		return this.byPath.get(refPath);
+	}
+
+	/** Replay every staged write onto the transaction in insertion order. */
+	flush(transaction: Transaction): void {
+		for (const entry of this.byPath.values()) {
+			if (entry.op === "create") transaction.set(entry.ref, entry.docData);
+			else transaction.update(entry.ref, entry.docData);
+		}
+	}
+}
+
+/**
+ * Evaluates a where clause against an in-memory app-side doc. AND-within-
+ * group, OR-between-groups (a new group starts at every `connector: "OR"`).
+ * Unknown operators fall back to equality — see TxBuffer header for the
+ * supported set.
+ */
+function matchesWhere(
+	appData: Record<string, any>,
+	where: WhereCondition[] | undefined,
+): boolean {
+	if (!where || where.length === 0) return true;
+	const groups: WhereCondition[][] = [];
+	let current: WhereCondition[] = [];
+	for (const cond of where) {
+		if (cond.connector === "OR" && current.length > 0) {
+			groups.push(current);
+			current = [cond];
+		} else {
+			current.push(cond);
+		}
+	}
+	if (current.length > 0) groups.push(current);
+	return groups.some((group) =>
+		group.every((cond) => matchesCondition(appData, cond)),
+	);
+}
+
+function matchesCondition(
+	appData: Record<string, any>,
+	cond: WhereCondition,
+): boolean {
+	const val = appData[cond.field];
+	const op = (cond.operator || "eq") as string;
+	switch (op) {
+		case "eq":
+		case "==":
+			return val === cond.value;
+		case "ne":
+		case "!=":
+			return val !== cond.value;
+		case "in":
+			return Array.isArray(cond.value)
+				? cond.value.includes(val)
+				: val === cond.value;
+		case "notIn":
+		case "not_in":
+			return Array.isArray(cond.value)
+				? !cond.value.includes(val)
+				: val !== cond.value;
+		case "gt":
+			return val > cond.value;
+		case "gte":
+			return val >= cond.value;
+		case "lt":
+			return val < cond.value;
+		case "lte":
+			return val <= cond.value;
+		case "contains":
+		case "array-contains":
+			if (Array.isArray(val)) return val.includes(cond.value);
+			if (typeof val === "string") return val.includes(String(cond.value));
+			return false;
+		case "startsWith":
+		case "starts-with":
+		case "starts_with":
+			return typeof val === "string" && val.startsWith(String(cond.value));
+		case "endsWith":
+		case "ends-with":
+		case "ends_with":
+			return typeof val === "string" && val.endsWith(String(cond.value));
+		default:
+			return val === cond.value;
+	}
+}
+
+/**
+ * Look up a single doc inside a transaction, mirroring the non-tx
+ * findOne/update path. Special-cases `id eq value` to use `col.doc(id)`
+ * because Firestore document IDs are metadata, not fields — they can't
+ * be queried with `.where("id", ...)`. Returns undefined when nothing
+ * matches.
+ */
+async function lookupTxDoc(
+	transaction: Transaction,
+	col: FirebaseFirestore.CollectionReference,
+	where: WhereCondition[] | undefined,
+	mapper: FieldMapper,
+): Promise<FirebaseFirestore.DocumentSnapshot | undefined> {
+	if (
+		where &&
+		where.length === 1 &&
+		where[0]?.field === "id" &&
+		(where[0]?.operator === "eq" || !where[0]?.operator)
+	) {
+		const docRef = col.doc(where[0].value as string);
+		const snap = await transaction.get(docRef);
+		return snap.exists ? snap : undefined;
+	}
+	for (const whereClause of getChunkedWhereClauses(where)) {
+		const q = applyWhereClause(col, whereClause, mapper);
+		const snap = await transaction.get(q.limit(1));
+		if (snap.docs[0]) return snap.docs[0];
+	}
+	return undefined;
+}
+
+/** Convert a Firestore document body (db-side keys, Timestamps) to app shape. */
+function dbDataToAppData(
+	data: Record<string, any>,
+	mapper: FieldMapper,
+): Record<string, any> {
+	const result: Record<string, any> = {};
+	for (const [k, v] of Object.entries(data)) {
+		if (k === "__name__") continue;
+		result[mapper.fromDb(k)] = convertTimestamp(v);
+	}
+	return result;
+}
+
 export interface FirestoreAdapterOptions
 	extends Omit<FirestoreAdapterConfig, "firestore"> {
 	firestore?: Firestore;
@@ -362,6 +602,8 @@ export const firestoreAdapter: (
 			debugLogs,
 			transaction: async (run) => {
 				return await db.runTransaction(async (transaction: Transaction) => {
+					const buffer = new TxBuffer();
+
 					const txAdapter = {
 						create: async ({ model, data }: any) => {
 							const col = getCollectionRef(db, model, collections);
@@ -371,54 +613,90 @@ export const firestoreAdapter: (
 								mapper,
 							);
 							const ref = idOverride ? col.doc(idOverride) : col.doc();
-							transaction.set(ref, docData);
-							return { ...normalizedData, id: ref.id };
+							const entry = buffer.stageCreate(
+								model,
+								ref,
+								docData,
+								normalizedData,
+							);
+							return { ...entry.appData };
 						},
 						update: async ({ model, where, update }: any) => {
 							const col = getCollectionRef(db, model, collections);
-							let doc: FirebaseFirestore.QueryDocumentSnapshot | undefined;
-							for (const whereClause of getChunkedWhereClauses(where)) {
-								const q = applyWhereClause(col, whereClause, mapper);
-								const snap = await transaction.get(q.limit(1));
-								doc = snap.docs[0];
-								if (doc) break;
-							}
-							if (!doc) return null;
 							const normalizedUpdate = normalizeWriteData(model, update);
 							const { docData: updateData } = buildFirestoreWriteData(
 								normalizedUpdate,
 								mapper,
 							);
-							transaction.update(doc.ref, updateData);
-							const existing = doc.data();
-							const result: any = { id: doc.id };
-							if (existing) {
-								for (const [k, v] of Object.entries(existing)) {
-									result[mapper.fromDb(k)] = v;
-								}
+
+							// 1. Overlay: target may already be staged as a create in
+							//    this same transaction. Mutate it in place so the flush
+							//    emits one combined `set`.
+							const stagedCreate = buffer.findCreateMatching(model, where);
+							if (stagedCreate) {
+								Object.assign(stagedCreate.docData, updateData);
+								Object.assign(stagedCreate.appData, normalizedUpdate);
+								return { ...stagedCreate.appData };
 							}
-							return { ...result, ...normalizedUpdate };
+
+							// 2. Otherwise read from Firestore (still safe — no writes
+							//    have been flushed yet) to locate the target doc.
+							const doc = await lookupTxDoc(
+								transaction,
+								col,
+								where,
+								mapper,
+							);
+							if (!doc) return null;
+
+							// 3. Same ref may already have an update staged; merge.
+							const existing = buffer.getByPath(doc.ref.path);
+							if (existing) {
+								Object.assign(existing.docData, updateData);
+								Object.assign(existing.appData, normalizedUpdate);
+								return { ...existing.appData };
+							}
+
+							// 4. Stage a fresh update.
+							const baseAppData = dbDataToAppData(doc.data() ?? {}, mapper);
+							const entry = buffer.stageUpdate(
+								model,
+								doc.ref,
+								updateData,
+								normalizedUpdate,
+								baseAppData,
+							);
+							return { ...entry.appData };
 						},
 						findOne: async ({ model, where }: any) => {
 							const col = getCollectionRef(db, model, collections);
-							let doc: FirebaseFirestore.QueryDocumentSnapshot | undefined;
-							for (const whereClause of getChunkedWhereClauses(where)) {
-								const q = applyWhereClause(col, whereClause, mapper);
-								const snap = await transaction.get(q.limit(1));
-								doc = snap.docs[0];
-								if (doc) break;
-							}
+
+							// 1. Overlay: return any matching staged create directly.
+							const stagedCreate = buffer.findCreateMatching(model, where);
+							if (stagedCreate) return { ...stagedCreate.appData };
+
+							// 2. Real read.
+							const doc = await lookupTxDoc(
+								transaction,
+								col,
+								where,
+								mapper,
+							);
 							if (!doc) return null;
+
+							// 3. Layer any pending update on top of the snapshot.
+							const staged = buffer.getByPath(doc.ref.path);
+							if (staged) return { ...staged.appData };
+
 							const data = doc.data();
 							if (!data) return null;
-							const result: any = { id: doc.id };
-							for (const [k, v] of Object.entries(data)) {
-								result[mapper.fromDb(k)] = convertTimestamp(v);
-							}
-							return result;
+							return { id: doc.id, ...dbDataToAppData(data, mapper) };
 						},
 					};
-					return run(txAdapter as any);
+
+					const result = await run(txAdapter as any);
+					buffer.flush(transaction);
+					return result;
 				});
 			},
 		},

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -347,3 +347,191 @@ describe("Emulator env does not alter default collection names", () => {
 		}
 	});
 });
+
+describe("Transaction buffering (regression for #24)", () => {
+	// All tests in this block use the same db + collection set. The tx
+	// wrapper doesn't branch on naming strategy, so we only need to cover
+	// one configuration here.
+	const db = initFirestore({ name: "test-tx", projectId: "test" });
+	const TX_COLLECTIONS = {
+		users: "tx_users",
+		sessions: "tx_sessions",
+		accounts: "tx_accounts",
+		verificationTokens: "tx_verificationTokens",
+	};
+	const adapter = firestoreAdapter({
+		firestore: db,
+		collections: TX_COLLECTIONS,
+		debugLogs: false,
+	})({}) as any;
+
+	afterEach(async () => {
+		for (const col of Object.values(TX_COLLECTIONS)) {
+			const snap = await db.collection(col).get();
+			await Promise.all(snap.docs.map((d) => d.ref.delete()));
+		}
+	});
+
+	it("commits a create inside a transaction (the bare #24 trigger)", async () => {
+		// Before the buffer refactor, this worked — only one Firestore op —
+		// but it sets the baseline.
+		const result = await adapter.transaction(async (tx: any) => {
+			return tx.create({
+				model: "user",
+				data: { email: "tx1@example.com", name: "T1" },
+			});
+		});
+		expect(result.id).toBeTruthy();
+
+		const found = await adapter.findOne({
+			model: "user",
+			where: [{ field: "id", operator: "eq", value: result.id }],
+		});
+		expect(found.email).toBe("tx1@example.com");
+	});
+
+	it("findOne after create returns the buffered doc (read-your-writes by id)", async () => {
+		const observed = await adapter.transaction(async (tx: any) => {
+			const created = await tx.create({
+				model: "user",
+				data: { email: "tx2@example.com", name: "T2" },
+			});
+			return tx.findOne({
+				model: "user",
+				where: [{ field: "id", operator: "eq", value: created.id }],
+			});
+		});
+		expect(observed).toBeTruthy();
+		expect(observed.email).toBe("tx2@example.com");
+	});
+
+	it("findOne after create overlays by non-id field too", async () => {
+		const observed = await adapter.transaction(async (tx: any) => {
+			await tx.create({
+				model: "user",
+				data: { email: "tx3@example.com", name: "T3" },
+			});
+			return tx.findOne({
+				model: "user",
+				where: [
+					{ field: "email", operator: "eq", value: "tx3@example.com" },
+				],
+			});
+		});
+		expect(observed).toBeTruthy();
+		expect(observed.name).toBe("T3");
+	});
+
+	it("create + update on the same buffered doc collapses to a single set on flush", async () => {
+		const observed = await adapter.transaction(async (tx: any) => {
+			const created = await tx.create({
+				model: "user",
+				data: { email: "tx4@example.com", name: "Original" },
+			});
+			return tx.update({
+				model: "user",
+				where: [{ field: "id", operator: "eq", value: created.id }],
+				update: { name: "Modified" },
+			});
+		});
+		expect(observed.name).toBe("Modified");
+		expect(observed.email).toBe("tx4@example.com");
+
+		// Persisted state reflects the merged write
+		const persisted = await adapter.findOne({
+			model: "user",
+			where: [{ field: "id", operator: "eq", value: observed.id }],
+		});
+		expect(persisted.name).toBe("Modified");
+		expect(persisted.email).toBe("tx4@example.com");
+	});
+
+	it("update + update on the same Firestore-resident doc merges into one update", async () => {
+		const seedRef = db.collection(TX_COLLECTIONS.users).doc();
+		await seedRef.set({ email: "tx5@example.com", name: "Seed" });
+
+		await adapter.transaction(async (tx: any) => {
+			await tx.update({
+				model: "user",
+				where: [{ field: "id", operator: "eq", value: seedRef.id }],
+				update: { name: "Update1" },
+			});
+			await tx.update({
+				model: "user",
+				where: [{ field: "id", operator: "eq", value: seedRef.id }],
+				update: { name: "Update2" },
+			});
+		});
+
+		const persisted = await seedRef.get();
+		expect(persisted.data()?.name).toBe("Update2");
+		// Email from the seed should survive — update is partial, not replace
+		expect(persisted.data()?.email).toBe("tx5@example.com");
+	});
+
+	it("findOne after update returns the merged state, not the pre-update snapshot", async () => {
+		const seedRef = db.collection(TX_COLLECTIONS.users).doc();
+		await seedRef.set({ email: "tx6@example.com", name: "Seed" });
+
+		const observed = await adapter.transaction(async (tx: any) => {
+			await tx.update({
+				model: "user",
+				where: [{ field: "id", operator: "eq", value: seedRef.id }],
+				update: { name: "Modified" },
+			});
+			return tx.findOne({
+				model: "user",
+				where: [{ field: "id", operator: "eq", value: seedRef.id }],
+			});
+		});
+		expect(observed.name).toBe("Modified");
+		expect(observed.email).toBe("tx6@example.com");
+	});
+
+	it("create(user) → findOne(session)[null] → create(session) — the actual #24 pattern", async () => {
+		// This is the exact interleaving that triggered #24 once
+		// secondaryStorage was wired in. With buffered writes, the findOne
+		// runs first against Firestore (no writes flushed yet) and the two
+		// creates flush after the callback resolves.
+		await adapter.transaction(async (tx: any) => {
+			const u = await tx.create({
+				model: "user",
+				data: { email: "tx7@example.com", name: "U" },
+			});
+
+			const existing = await tx.findOne({
+				model: "session",
+				where: [{ field: "userId", operator: "eq", value: u.id }],
+			});
+			expect(existing).toBeNull();
+
+			await tx.create({
+				model: "session",
+				data: {
+					userId: u.id,
+					expires: new Date("2030-01-01T00:00:00.000Z"),
+				},
+			});
+		});
+
+		const users = await db.collection(TX_COLLECTIONS.users).get();
+		const sessions = await db.collection(TX_COLLECTIONS.sessions).get();
+		expect(users.size).toBe(1);
+		expect(sessions.size).toBe(1);
+	});
+
+	it("throwing inside the callback aborts the transaction (no partial writes)", async () => {
+		await expect(
+			adapter.transaction(async (tx: any) => {
+				await tx.create({
+					model: "user",
+					data: { email: "tx8@example.com", name: "Aborted" },
+				});
+				throw new Error("intentional");
+			}),
+		).rejects.toThrow("intentional");
+
+		const users = await db.collection(TX_COLLECTIONS.users).get();
+		expect(users.size).toBe(0);
+	});
+});

--- a/tests/secondary-storage.test.ts
+++ b/tests/secondary-storage.test.ts
@@ -19,7 +19,7 @@ async function clearAll(db: Firestore) {
 	}
 }
 
-describe("better-auth with Firestore secondaryStorage (repro for #24)", () => {
+describe("better-auth with Firestore secondaryStorage (regression for #24)", () => {
 	const db = initFirestore({ name: "test-ss", projectId: "test" });
 
 	const auth = betterAuth({
@@ -42,30 +42,25 @@ describe("better-auth with Firestore secondaryStorage (repro for #24)", () => {
 		await clearAll(db);
 	});
 
-	// `it.fails` until #24 is resolved: today better-auth's signUpEmail calls
-	// `createSession` (which does a `findOne` read) inside the same transaction
-	// where `create(user)` has already done a `transaction.set` — Firestore
-	// rejects with "transactions require all reads to be executed before all
-	// writes." When the tx wrapper is refactored to buffer writes and overlay
-	// reads, this test will start passing and `it.fails` will itself fail,
-	// signaling that the modifier should be removed.
-	it.fails(
-		"signs up and signs in without violating Firestore txn read-before-write",
-		async () => {
-			const email = `u-${Date.now()}@example.com`;
-			const password = "password1234";
+	// The tx wrapper buffers writes during the user callback and flushes them
+	// after the callback resolves, so Firestore's "all reads before all writes"
+	// rule is honored even when better-auth interleaves create + findOne +
+	// create inside one transaction (as `signUpEmail` does once
+	// `secondaryStorage` is configured).
+	it("signs up and signs in without violating Firestore txn read-before-write", async () => {
+		const email = `u-${Date.now()}@example.com`;
+		const password = "password1234";
 
-			const signUp = await auth.api.signUpEmail({
-				body: { email, password, name: "Repro User" },
-				asResponse: true,
-			});
-			expect(signUp.status).toBe(200);
+		const signUp = await auth.api.signUpEmail({
+			body: { email, password, name: "Repro User" },
+			asResponse: true,
+		});
+		expect(signUp.status).toBe(200);
 
-			const signIn = await auth.api.signInEmail({
-				body: { email, password },
-				asResponse: true,
-			});
-			expect(signIn.status).toBe(200);
-		},
-	);
+		const signIn = await auth.api.signInEmail({
+			body: { email, password },
+			asResponse: true,
+		});
+		expect(signIn.status).toBe(200);
+	});
 });


### PR DESCRIPTION
Closes #24.

## The bug

Firestore's transaction API requires every `transaction.get` in a `runTransaction` callback to complete **before** any `transaction.set` / `update` / `delete`:

> `Firestore transactions require all reads to be executed before all writes.`

better-auth interleaves them freely. A sign-up with `secondaryStorage` configured does (inside one tx):

1. `create(user)` → `transaction.set` ← write
2. `findOne(session by token)` → `transaction.get` ← **read after write** → throws

The `it.fails`-marked repro added in #25 documented this; the call site is `Object.findOne` at [src/firebase-adapter.ts](src/firebase-adapter.ts) inside the `runTransaction` callback at line 364.

## The fix

Per-transaction `TxBuffer`. The tx wrapper no longer writes to Firestore during the user callback; it only stages.

- `create` / `update` push entries into the buffer.
- `findOne` and `update`'s lookup **overlay the buffer first**. On a miss they fall through to `transaction.get` — still legal, because nothing has been written through the SDK yet. The callback observes its own writes (transactional read-your-writes).
- After `run(txAdapter)` resolves, `buffer.flush(transaction)` replays every staged op as `transaction.set` / `update` in insertion order. Firestore then commits atomically.

**Op merging** (collapses redundant writes against the same ref):

- `create(x) → update(x)`: merged into the `create` entry in place → flush emits a single `set`.
- `update(x) → update(x)`: merged into the existing `update` entry → flush emits a single combined `update`.

**Retry safety:** the buffer is constructed *inside* the `runTransaction` callback, so Firestore's automatic retries on contention get a fresh buffer each pass.

**Error safety:** if the user callback throws, `flush` is never reached and `runTransaction` aborts — no partial writes.

## Sub-fix: `id eq value` lookups inside transactions

While writing tests I hit a separate bug in the tx paths: `findOne` / `update` with `where: [{ field: "id", operator: "eq", value }]` was issuing `query.where("id", "==", value)`, which always returns empty because Firestore document IDs are metadata, not fields. The non-tx paths already special-cased this with `col.doc(id)`; a new `lookupTxDoc` helper now does the same for the tx paths.

## Read-overlay scope (`matchesWhere`)

Handles the operators better-auth uses inside transactions: `eq`, `ne`, `in`, `notIn`, `gt(e)`, `lt(e)`, `contains`, `startsWith`, `endsWith`, plus AND/OR connectors. Unrecognized operators fall back to equality — documented in the buffer header as a known limitation since better-auth doesn't generate exotic where-clauses inside tx callbacks.

## Tests

New `Transaction buffering (regression for #24)` block in [tests/index.test.ts](tests/index.test.ts) (8 tests):

| Test | Covers |
|---|---|
| commits a create inside a transaction | bare #24 trigger |
| findOne after create returns the buffered doc (by id) | overlay by id |
| findOne after create overlays by non-id field too | `matchesWhere` `eq` on `email` |
| create + update collapses to a single set on flush | in-place merge into a buffered create |
| update + update on Firestore-resident doc merges into one update | in-place merge into a buffered update |
| findOne after update returns the merged state | overlay of buffered updates |
| `create(user) → findOne(session)[null] → create(session)` | the exact #24 pattern |
| throwing inside the callback aborts the transaction | no partial writes |

The `secondaryStorage` integration test in [tests/secondary-storage.test.ts](tests/secondary-storage.test.ts) is no longer `it.fails` — the full sign-up + sign-in flow through better-auth now completes cleanly.

## Test results

```
Test Files  2 passed (2)
     Tests  23 passed (23)
```

14 from the original suite + 8 new tx tests + 1 secondary-storage integration test.