### PR TITLE
chore(ci): bump pnpm/action-setup v4 → v6 (Node.js 24)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.0.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.0.0
 


### PR DESCRIPTION
GitHub Actions deprecated Node.js 20 in September 2025; `pnpm/action-setup@v4` still runs on it:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `pnpm/action-setup@v4`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

`pnpm/action-setup` v5.0.0 upgraded its runtime to Node.js 24, and v6.0.0 added pnpm 11 support. The `version` input is unchanged between v4 and v6, so this is a drop-in bump.

## Diff

```diff
- uses: pnpm/action-setup@v4
+ uses: pnpm/action-setup@v6
  with:
    version: 10.0.0
```

Applied to both `.github/workflows/release.yml` and `.github/workflows/pr-checks.yml`.

## Release impact

None. This commit is `chore(ci)` — your `.releaserc.json` only adds patch releases for `chore(deps)` and `chore(security)`; `chore(ci)` defers to the Angular preset default, which is no release.