### PR TITLE
chore: drop chore(deps) from semantic-release rules

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,6 @@
       {
         "preset": "angular",
         "releaseRules": [
-          { "type": "chore", "scope": "deps", "release": "patch" },
           { "type": "chore", "scope": "security", "release": "patch" }
         ]
       }


### PR DESCRIPTION
Tightens [.releaserc.json](.releaserc.json) so routine Dependabot bumps don't cut releases that ship nothing to users.

## Why

`package.json` declares only `peerDependencies` (user-controlled) and `devDependencies` (not in the published tarball). A `chore(deps)` bump to e.g. vitest, biome, or anything in `examples/minimal/` produces a new npm version that is **byte-identical** for consumers vs the previous release — pure noise in the changelog and version history.

`chore(security)` stays mapped to patch — those bumps reflect intentional security work that should ship.

History already uses the right convention when a dep bump genuinely matters:
- [eeee9dc](https://github.com/yultyyev/better-auth-firestore/commit/eeee9dc) — `fix: resolve Dependabot security advisories in dependency graph` → `fix:` (Angular preset → patch)
- [#21](https://github.com/yultyyev/better-auth-firestore/pull/21) — `chore(security): fix transitive CVEs and harden CI pipeline` → custom rule → patch

## Diff

```diff
 "releaseRules": [
-  { "type": "chore", "scope": "deps", "release": "patch" },
   { "type": "chore", "scope": "security", "release": "patch" }
 ]
```

## If a dep bump ever needs to release

This repo currently has no runtime `dependencies` — only peer and dev. If that changes, the existing convention handles it: retitle the squash to `fix:` (or `fix(deps):`) at merge time. The Angular preset maps `fix:` → patch regardless of scope.

## Release impact

None for this PR. This commit is unscoped `chore:`, which the Angular preset (and the remaining custom rule) treats as no-release.