### PR TITLE
docs: add SKILL.md, AGENTS.md, and README visibility improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Helper: `generateIndexSetupUrl(projectId, databaseId?, collectionName?)` — gen
 
 ## Important Constraints
 
-- **Edge runtime not supported** — Firebase Admin SDK requires Node.js. Vercel Edge Functions and Cloudflare Workers are not supported.
+- **Edge Runtime not supported** — Firebase Admin SDK requires Node.js. If a route sets `export const runtime = 'edge'`, the Admin SDK will not load. Standard Vercel deployments (Node.js serverless runtime) work fine.
 - **FIREBASE_PRIVATE_KEY newlines** — Environment variables often store the key with literal `\n` strings. Users must call `.replace(/\\n/g, "\n")`.
 - **Scoped package deprecated** — `@yultyyev/better-auth-firestore` → `better-auth-firestore`. The API is identical; only the import path changes.
 - **Emulator support** — Set `FIRESTORE_EMULATOR_HOST=localhost:8080`; the Admin SDK automatically routes requests there. No credentials needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,132 @@
+# AI Assistant Guidelines
+
+This document provides additional context for AI assistants working on this project. **Please read [README.md](./README.md) first** for project overview and features.
+
+## Quick Reference
+
+- **Package name:** `better-auth-firestore` (unscoped — `@yultyyev/better-auth-firestore` is deprecated)
+- **Main Documentation:** See [README.md](./README.md)
+- **Contributing Guidelines:** See [CONTRIBUTING.md](./CONTRIBUTING.md)
+- **Adapter Guide:** See [Better Auth Adapter Guide](https://www.better-auth.com/docs/guides/create-a-db-adapter)
+
+## Current Project State
+
+All phases are complete. The adapter is production-ready and actively maintained.
+
+**Phase 1: Core Adapter** ✅ Complete  
+**Phase 2: Collection naming strategies** ✅ Complete  
+**Phase 3: Composite index tooling** ✅ Complete (`generateIndexSetupUrl`)  
+**Phase 4: Emulator support** ✅ Complete  
+**Phase 5: Tests (Vitest + Firestore Emulator)** ✅ Complete  
+**Phase 6: CI/CD and Example Project** ✅ Complete  
+**Phase 7: Migration from scoped package** ✅ Complete  
+
+## Project Structure
+
+```
+src/
+  firebase-adapter.ts    # Core Firestore adapter implementation
+  firestore.ts           # initFirestore helper and Firestore utilities
+  setup.ts               # generateIndexSetupUrl helper
+  types.ts               # TypeScript types for adapter options
+  index.ts               # Public exports
+tests/
+  *.test.ts              # Vitest integration tests (run against Firestore Emulator)
+examples/
+  minimal/               # Minimal Next.js App Router example
+scripts/                 # Build/release scripts
+```
+
+## Key Exports
+
+```ts
+import {
+  firestoreAdapter,         // Main adapter factory
+  initFirestore,            // Helper to initialize Firebase Admin + Firestore
+  generateIndexSetupUrl,    // Generate Firebase Console URL for index creation
+} from "better-auth-firestore";
+```
+
+## Adapter Options
+
+```ts
+firestoreAdapter({
+  firestore?: Firestore;          // Firebase Admin Firestore instance (default: getFirestore())
+  namingStrategy?: "default" | "snake_case";  // Collection naming convention
+  collections?: {
+    users?: string;
+    sessions?: string;
+    accounts?: string;
+    verificationTokens?: string;
+  };
+  debugLogs?: boolean | DBAdapterDebugLogOption;
+});
+```
+
+## Required Firestore Index
+
+The adapter requires a composite index on the verification collection. Without it, `verificationToken` queries fail. Always remind users to create it when setting up a new project.
+
+Fields: `identifier` (ASC), `createdAt` (DESC), `__name__` (DESC), scope: Collection.
+
+Helper: `generateIndexSetupUrl(projectId, databaseId?, collectionName?)` — generates the Firebase Console URL that pre-fills the index creation form.
+
+## Important Constraints
+
+- **Edge runtime not supported** — Firebase Admin SDK requires Node.js. Vercel Edge Functions and Cloudflare Workers are not supported.
+- **FIREBASE_PRIVATE_KEY newlines** — Environment variables often store the key with literal `\n` strings. Users must call `.replace(/\\n/g, "\n")`.
+- **Scoped package deprecated** — `@yultyyev/better-auth-firestore` → `better-auth-firestore`. The API is identical; only the import path changes.
+- **Emulator support** — Set `FIRESTORE_EMULATOR_HOST=localhost:8080`; the Admin SDK automatically routes requests there. No credentials needed.
+
+## Sister Package
+
+`better-auth-firebase-auth` ([GitHub](https://github.com/yultyyev/better-auth-firebase-auth)) is the companion Firebase Authentication plugin. It handles Phone OTP, Google Sign-In, and Email/Password via Firebase. The two packages are designed to be used together:
+
+- `better-auth-firestore` — database storage layer
+- `better-auth-firebase-auth` — authentication/identity layer
+
+## Code Style
+
+- BiomeJS for formatting (tab indentation)
+- TypeScript strict mode
+- No classes — follow Better Auth's functional plugin conventions
+- Keep functions small and focused
+
+## Build Commands
+
+```bash
+pnpm install       # Install dependencies
+pnpm build         # Build the project (outputs to dist/)
+pnpm test          # Run tests (requires FIRESTORE_EMULATOR_HOST)
+pnpm lint          # Check for linting issues
+pnpm lint:fix      # Fix auto-fixable linting issues
+```
+
+## Test Setup
+
+Tests use Vitest and run against the Firestore Emulator:
+
+```bash
+docker run -d --rm -p 8080:8080 google/cloud-sdk:emulators \
+  gcloud beta emulators firestore start --host-port=0.0.0.0:8080
+
+FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm vitest run
+```
+
+## Commit Messages
+
+Follow Conventional Commits:
+
+- `feat(adapter): description` — New features
+- `fix(adapter): description` — Bug fixes
+- `docs: description` — Documentation changes
+- `chore: description` — Build/tooling changes
+- `test: description` — Test changes
+
+## References
+
+- [Better Auth Documentation](https://www.better-auth.com/docs)
+- [Better Auth Adapter Guide](https://www.better-auth.com/docs/guides/create-a-db-adapter)
+- [Firebase Admin SDK Docs](https://firebase.google.com/docs/admin/setup)
+- [Firestore Emulator](https://firebase.google.com/docs/emulator-suite/connect_firestore)
+- [better-auth-firebase-auth](https://github.com/yultyyev/better-auth-firebase-auth)

--- a/README.md
+++ b/README.md
@@ -236,9 +236,12 @@ firestoreAdapter({
 | Runtime | Supported | Notes |
 |---|---|---|
 | Node 18+ | ✅ | Recommended |
-| Next.js (App Router) | ✅ | Server routes only |
+| Next.js on Vercel (Node.js runtime) | ✅ | Default serverless runtime — fully supported |
 | Cloud Functions / Cloud Run | ✅ | Provide `FIREBASE_*` creds |
-| Vercel Edge / CF Workers | ❌ | Firestore Admin SDK not supported at Edge runtime |
+| Vercel Edge Runtime (`runtime = 'edge'`) | ❌ | Firebase Admin SDK requires Node.js |
+| Cloudflare Workers | ❌ | Firebase Admin SDK requires Node.js |
+
+> **Vercel works.** The ❌ above applies only if you explicitly set `export const runtime = 'edge'` on a route. The default Node.js serverless runtime on Vercel is fully supported.
 
 ## Collections & Data Shape
 
@@ -471,7 +474,7 @@ Yes. `better-auth-firestore` is designed as a drop-in replacement for the Auth.j
 
 ### Which runtimes are supported?
 
-This package supports server-side Node.js runtimes, including Next.js route handlers, Cloud Functions, and Cloud Run, anywhere the Firebase Admin SDK is supported. Edge runtimes such as Vercel Edge Functions and Cloudflare Workers are not supported because the Firestore Admin SDK does not run there. See [Runtime compatibility](#runtime-compatibility) for the current matrix.
+This package supports any server-side Node.js runtime: Next.js on Vercel (the default serverless runtime), Cloud Functions, Cloud Run, and standalone Node.js. The only restriction is the Edge Runtime — if you explicitly set `export const runtime = 'edge'` on a route, the Firebase Admin SDK will not load. Standard Vercel deployments are fully supported. See [Runtime compatibility](#runtime-compatibility) for the full matrix.
 
 ### Why is a Firestore composite index required for verification tokens?
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/better-auth-firestore.svg)](https://www.npmjs.com/package/better-auth-firestore)
 [![CI](https://github.com/yultyyev/better-auth-firestore/actions/workflows/release.yml/badge.svg)](https://github.com/yultyyev/better-auth-firestore/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
+[![skills.sh](https://skills.sh/b/yultyyev/better-auth-firestore)](https://skills.sh/yultyyev/better-auth-firestore)
 
 > **Note:** If you're using `@yultyyev/better-auth-firestore`, please migrate to `better-auth-firestore`. The scoped package is deprecated. See [Migration from Scoped Package](#migration-from-scoped-package) below.
 
@@ -18,12 +19,22 @@
 
 For Firebase Authentication integration with Better Auth, see **[better-auth-firebase-auth](https://github.com/yultyyev/better-auth-firebase-auth)**. It provides:
 
-- Firebase Authentication provider support (Email/Password, Google, etc.)
-- Client-side or server-side token generation
-- Password reset functionality
-- Full TypeScript support
+- Firebase Phone Authentication (SMS OTP) — no Twilio required
+- Google Sign-In via Firebase OAuth flow
+- Email/Password sign-in and password reset via Firebase
+- Full TypeScript support with separate server/client entry points
 
-Use `better-auth-firebase-auth` for authentication and `better-auth-firestore` for data storage.
+Use `better-auth-firebase-auth` for authentication and `better-auth-firestore` for data storage. They are designed to be used together:
+
+```ts
+import { firestoreAdapter } from "better-auth-firestore";
+import { firebaseAuthPlugin } from "better-auth-firebase-auth/server";
+
+export const auth = betterAuth({
+  database: firestoreAdapter({ firestore }),
+  plugins: [firebaseAuthPlugin({ firebaseAdminAuth: getAuth() })],
+});
+```
 
 ---
 
@@ -466,10 +477,23 @@ This package supports server-side Node.js runtimes, including Next.js route hand
 
 Better Auth verification token lookups require a Firestore query pattern that depends on a composite index. Without that index, verification-related queries can fail with a missing index error or insufficient permissions message. See [Create Required Firestore Index](#3-create-required-firestore-index) for the exact fields and setup options.
 
+## AI Assistant Skill
+
+A `SKILL.md` is included at the root of this repo. It works with Cursor, Claude Code, Codex, Copilot, Windsurf, and [70+ other agents](https://skills.sh) via the skills.sh ecosystem.
+
+The skill teaches AI assistants the correct setup, required Firestore index, environment variable handling, and common gotchas. It also triggers when you ask about using Firestore with Better Auth, migrating from Auth.js/NextAuth, or troubleshooting `FIREBASE_PRIVATE_KEY` issues.
+
+```bash
+npx skills add yultyyev/better-auth-firestore
+```
+
+---
+
 ## Related Links
 
 - [Better Auth Documentation](https://www.better-auth.com/docs)
 - [Better Auth Adapter Guide](https://www.better-auth.com/docs/guides/create-a-db-adapter)
+- [better-auth-firebase-auth](https://github.com/yultyyev/better-auth-firebase-auth) — Firebase Auth plugin (Phone OTP, Google, Email/Password)
 - [Auth.js Firebase Adapter](https://authjs.dev/getting-started/adapters/firebase) (legacy, for reference)
 - [Auth.js joins Better Auth](https://www.better-auth.com/blog/authjs-joins-better-auth) - Announcement
 
@@ -478,6 +502,10 @@ Better Auth verification token lookups require a Firestore query pattern that de
 ```bash
 pnpm build
 ```
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and code style.
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -192,9 +192,12 @@ No credentials or service account needed when using the emulator.
 | Runtime | Supported |
 |---|---|
 | Node 18+ | ✅ |
-| Next.js App Router (server) | ✅ |
+| Next.js on Vercel (Node.js runtime) | ✅ Recommended |
 | Cloud Functions / Cloud Run | ✅ |
-| Vercel Edge / CF Workers | ❌ (Admin SDK not supported at edge) |
+| Vercel Edge Runtime (`runtime = 'edge'`) | ❌ Admin SDK requires Node.js |
+| Cloudflare Workers | ❌ Admin SDK requires Node.js |
+
+**Note:** Vercel deploys work fine — the restriction is only when you explicitly opt into the Edge Runtime (`export const runtime = 'edge'`). The default Node.js serverless runtime on Vercel is fully supported.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: firestore-better-auth
+description: >-
+  Use Firestore as the database adapter for Better Auth (Firebase Admin SDK).
+  Use when storing Better Auth users, sessions, accounts, and verification
+  tokens in Firestore, migrating from Auth.js/NextAuth Firebase adapter to
+  Better Auth, setting up Better Auth with a Firebase/Firestore backend, or
+  troubleshooting Firestore index errors and FIREBASE_PRIVATE_KEY issues.
+---
+
+# Firestore Adapter for Better Auth
+
+`better-auth-firestore` is the Firestore database adapter for [Better Auth](https://better-auth.com). It stores users, sessions, accounts, and verification tokens in Firestore using the Firebase Admin SDK.
+
+**Package:** `better-auth-firestore` — [GitHub](https://github.com/yultyyev/better-auth-firestore) · [npm](https://www.npmjs.com/package/better-auth-firestore)
+
+---
+
+## Install
+
+```bash
+pnpm add better-auth-firestore firebase-admin better-auth
+```
+
+---
+
+## Minimal setup
+
+```ts
+import { firestoreAdapter } from "better-auth-firestore";
+import { betterAuth } from "better-auth";
+import { getFirestore } from "firebase-admin/firestore";
+
+export const auth = betterAuth({
+  database: firestoreAdapter({ firestore: getFirestore() }),
+});
+```
+
+---
+
+## Full setup with credentials
+
+```ts
+import { betterAuth } from "better-auth";
+import { firestoreAdapter, initFirestore } from "better-auth-firestore";
+import { cert } from "firebase-admin/app";
+
+const firestore = initFirestore({
+  credential: cert({
+    projectId: process.env.FIREBASE_PROJECT_ID!,
+    clientEmail: process.env.FIREBASE_CLIENT_EMAIL!,
+    privateKey: process.env.FIREBASE_PRIVATE_KEY!.replace(/\\n/g, "\n"),
+  }),
+  projectId: process.env.FIREBASE_PROJECT_ID!,
+  name: "better-auth",
+});
+
+export const auth = betterAuth({
+  database: firestoreAdapter({
+    firestore,
+    namingStrategy: "default", // or "snake_case"
+    collections: {
+      // users: "users",
+      // sessions: "sessions",
+      // accounts: "accounts",
+      // verificationTokens: "verificationTokens",
+    },
+  }),
+});
+```
+
+---
+
+## Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `firestore` | `Firestore` | `getFirestore()` | Firebase Admin Firestore instance |
+| `namingStrategy` | `"default" \| "snake_case"` | `"default"` | Collection naming convention |
+| `collections` | `object` | see below | Override individual collection names |
+| `debugLogs` | `boolean` | `false` | Enable verbose query logging |
+
+**Default collection names:**
+- `users` → `"users"`
+- `sessions` → `"sessions"`
+- `accounts` → `"accounts"`
+- `verificationTokens` → `"verificationTokens"` (default) or `"verification_tokens"` (snake_case)
+
+---
+
+## Required Firestore composite index
+
+The adapter requires a composite index on the `verification` collection for token lookups. Without it, Better Auth sign-in verification will fail.
+
+**Quick setup — generate the Firebase Console URL:**
+
+```ts
+import { generateIndexSetupUrl } from "better-auth-firestore";
+const url = generateIndexSetupUrl(process.env.FIREBASE_PROJECT_ID!);
+console.log(url); // Open to auto-fill the index form
+```
+
+**Or deploy via CLI:**
+
+Copy `firestore.indexes.json` from `node_modules/better-auth-firestore/` to your project root, then:
+
+```bash
+firebase deploy --only firestore:indexes
+```
+
+**Index fields:**
+- Collection: `verification`
+- `identifier` (Ascending)
+- `createdAt` (Descending)
+- `__name__` (Descending)
+- Query scope: Collection
+
+---
+
+## Environment variables
+
+```bash
+FIREBASE_PROJECT_ID=your-project-id
+FIREBASE_CLIENT_EMAIL=firebase-adminsdk@your-project.iam.gserviceaccount.com
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+```
+
+**Important:** `FIREBASE_PRIVATE_KEY` often arrives with literal `\n` strings in env vars. Always replace them:
+
+```ts
+privateKey: process.env.FIREBASE_PRIVATE_KEY!.replace(/\\n/g, "\n")
+```
+
+---
+
+## Migration from Auth.js / NextAuth Firebase adapter
+
+`better-auth-firestore` uses the same collection names and field shapes as the Auth.js Firebase adapter by default — it is a drop-in replacement.
+
+```ts
+// Before (Auth.js)
+import { FirestoreAdapter } from "@auth/firebase-adapter";
+
+// After (Better Auth)
+import { firestoreAdapter } from "better-auth-firestore";
+
+export const auth = betterAuth({
+  database: firestoreAdapter({ firestore }),
+});
+```
+
+No Firestore data migration needed. Same `users`, `sessions`, `accounts`, and `verificationTokens` collections.
+
+---
+
+## Using with the Firebase Auth plugin
+
+To also use Firebase Authentication (Phone OTP, Google Sign-In, Email/Password), combine with `better-auth-firebase-auth`:
+
+```ts
+import { firestoreAdapter } from "better-auth-firestore";
+import { firebaseAuthPlugin } from "better-auth-firebase-auth/server";
+
+export const auth = betterAuth({
+  database: firestoreAdapter({ firestore }),
+  plugins: [firebaseAuthPlugin({ firebaseAdminAuth: getAuth() })],
+});
+```
+
+---
+
+## Firestore Emulator (local development & tests)
+
+```bash
+# Start emulator
+docker run -d --rm -p 8080:8080 google/cloud-sdk:emulators \
+  gcloud beta emulators firestore start --host-port=0.0.0.0:8080
+
+# Set env and start dev server
+FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm dev
+
+# Run tests
+FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm vitest run
+```
+
+No credentials or service account needed when using the emulator.
+
+---
+
+## Runtime support
+
+| Runtime | Supported |
+|---|---|
+| Node 18+ | ✅ |
+| Next.js App Router (server) | ✅ |
+| Cloud Functions / Cloud Run | ✅ |
+| Vercel Edge / CF Workers | ❌ (Admin SDK not supported at edge) |
+
+---
+
+## Common mistakes
+
+- **Missing Firestore composite index** — Verification token queries fail with "index required" or "insufficient permissions". Run `generateIndexSetupUrl` to get the setup link.
+- **FIREBASE_PRIVATE_KEY with literal `\n`** — Always call `.replace(/\\n/g, "\n")` on the key before passing to `cert()`.
+- **Using at edge runtime** — Firebase Admin SDK does not run on Vercel Edge or Cloudflare Workers. Use Node.js runtimes only.
+- **Deprecated scoped package** — Use `better-auth-firestore` (unscoped). The `@yultyyev/better-auth-firestore` package is deprecated.


### PR DESCRIPTION
## Summary

- **`SKILL.md`** — adds this package to the [skills.sh](https://skills.sh) ecosystem, making it discoverable by Cursor, Claude Code, Codex, Copilot, Windsurf, and 70+ other AI agents via `npx skills add yultyyev/better-auth-firestore`. Covers setup, Firestore index creation, env var gotchas, migration from Auth.js, and common mistakes.
- **`AGENTS.md`** — project context for AI assistants working on the codebase itself (project state, file structure, key exports, constraints, commit conventions). Mirrors the pattern from the sister project [better-auth-firebase-auth](https://github.com/yultyyev/better-auth-firebase-auth).
- **`README.md`** — skills.sh badge, expanded "Related: Firebase Auth Plugin" section with combined-usage code example, new "AI Assistant Skill" section with `npx skills add` command, `better-auth-firebase-auth` added to Related Links, Contributing section added.

## Test plan

- [ ] Verify badge renders correctly on GitHub: `[![skills.sh](https://skills.sh/b/yultyyev/better-auth-firestore)](https://skills.sh/yultyyev/better-auth-firestore)`
- [ ] Confirm `npx skills add yultyyev/better-auth-firestore` works once registered at skills.sh
- [ ] No code changes — docs only, CI should pass