### PR TITLE
fix: implement findMany, deleteMany, and consumeOne on the tx adapter

### DIFF
--- a/src/firebase-adapter.ts
+++ b/src/firebase-adapter.ts
@@ -264,7 +264,9 @@ function isDocumentReferenceLike(value: unknown): value is { id: string } {
 	);
 }
 
-function normalizeSessionWriteData(data: Record<string, any>): Record<string, any> {
+function normalizeSessionWriteData(
+	data: Record<string, any>,
+): Record<string, any> {
 	const { user_id, session_token, ...rest } = data;
 	const normalized: Record<string, any> = { ...rest };
 
@@ -283,7 +285,10 @@ function normalizeSessionWriteData(data: Record<string, any>): Record<string, an
 	return normalized;
 }
 
-function normalizeWriteData(model: string, data: Record<string, any>): Record<string, any> {
+function normalizeWriteData(
+	model: string,
+	data: Record<string, any>,
+): Record<string, any> {
 	const normalizedModel = model.toLowerCase().replace(/s$/, "");
 	if (normalizedModel !== "session") return data;
 	return normalizeSessionWriteData(data);
@@ -348,10 +353,8 @@ function buildFirestoreWriteData(
 // buffered docs of the same model — in practice better-auth never
 // generates such clauses inside its tx callbacks.
 
-type TxBufferOp = "create" | "update";
-
-interface TxBufferEntry {
-	op: TxBufferOp;
+interface TxBufferWriteEntry {
+	op: "create" | "update";
 	model: string;
 	ref: FirebaseFirestore.DocumentReference;
 	/**
@@ -367,6 +370,14 @@ interface TxBufferEntry {
 	appData: Record<string, any>;
 }
 
+interface TxBufferDeleteEntry {
+	op: "delete";
+	model: string;
+	ref: FirebaseFirestore.DocumentReference;
+}
+
+type TxBufferEntry = TxBufferWriteEntry | TxBufferDeleteEntry;
+
 class TxBuffer {
 	private byPath = new Map<string, TxBufferEntry>();
 
@@ -376,8 +387,8 @@ class TxBuffer {
 		ref: FirebaseFirestore.DocumentReference,
 		docData: Record<string, any>,
 		appNormalized: Record<string, any>,
-	): TxBufferEntry {
-		const entry: TxBufferEntry = {
+	): TxBufferWriteEntry {
+		const entry: TxBufferWriteEntry = {
 			op: "create",
 			model,
 			ref,
@@ -401,14 +412,14 @@ class TxBuffer {
 		updateDocData: Record<string, any>,
 		updateAppData: Record<string, any>,
 		baseAppData: Record<string, any>,
-	): TxBufferEntry {
+	): TxBufferWriteEntry {
 		const existing = this.byPath.get(ref.path);
-		if (existing) {
+		if (existing && existing.op !== "delete") {
 			Object.assign(existing.docData, updateDocData);
 			Object.assign(existing.appData, updateAppData);
 			return existing;
 		}
-		const entry: TxBufferEntry = {
+		const entry: TxBufferWriteEntry = {
 			op: "update",
 			model,
 			ref,
@@ -423,7 +434,7 @@ class TxBuffer {
 	findCreateMatching(
 		model: string,
 		where: WhereCondition[] | undefined,
-	): TxBufferEntry | undefined {
+	): TxBufferWriteEntry | undefined {
 		for (const entry of this.byPath.values()) {
 			if (entry.op !== "create" || entry.model !== model) continue;
 			if (matchesWhere(entry.appData, where)) return entry;
@@ -431,16 +442,34 @@ class TxBuffer {
 		return undefined;
 	}
 
-	/** Buffered entry (create or update) for a specific ref path, if any. */
+	/** Stage a delete on `ref`, discarding any prior create/update for the same path. */
+	stageDelete(model: string, ref: FirebaseFirestore.DocumentReference): void {
+		this.byPath.set(ref.path, { op: "delete", model, ref });
+	}
+
+	/** True if `ref` has a delete staged. */
+	isDeleted(refPath: string): boolean {
+		const entry = this.byPath.get(refPath);
+		return !!entry && entry.op === "delete";
+	}
+
+	/** Buffered entry (create, update, or delete) for a specific ref path, if any. */
 	getByPath(refPath: string): TxBufferEntry | undefined {
 		return this.byPath.get(refPath);
+	}
+
+	/** All buffered entries, for scanning staged creates by model. */
+	values(): IterableIterator<TxBufferEntry> {
+		return this.byPath.values();
 	}
 
 	/** Replay every staged write onto the transaction in insertion order. */
 	flush(transaction: Transaction): void {
 		for (const entry of this.byPath.values()) {
 			if (entry.op === "create") transaction.set(entry.ref, entry.docData);
-			else transaction.update(entry.ref, entry.docData);
+			else if (entry.op === "update")
+				transaction.update(entry.ref, entry.docData);
+			else transaction.delete(entry.ref);
 		}
 	}
 }
@@ -641,17 +670,14 @@ export const firestoreAdapter: (
 
 							// 2. Otherwise read from Firestore (still safe — no writes
 							//    have been flushed yet) to locate the target doc.
-							const doc = await lookupTxDoc(
-								transaction,
-								col,
-								where,
-								mapper,
-							);
+							const doc = await lookupTxDoc(transaction, col, where, mapper);
 							if (!doc) return null;
 
 							// 3. Same ref may already have an update staged; merge.
+							//    (A staged delete is skipped — falls through to stage a
+							//    fresh update below, mirroring "not currently buffered".)
 							const existing = buffer.getByPath(doc.ref.path);
-							if (existing) {
+							if (existing && existing.op !== "delete") {
 								Object.assign(existing.docData, updateData);
 								Object.assign(existing.appData, normalizedUpdate);
 								return { ...existing.appData };
@@ -676,21 +702,114 @@ export const firestoreAdapter: (
 							if (stagedCreate) return { ...stagedCreate.appData };
 
 							// 2. Real read.
-							const doc = await lookupTxDoc(
-								transaction,
-								col,
-								where,
-								mapper,
-							);
+							const doc = await lookupTxDoc(transaction, col, where, mapper);
 							if (!doc) return null;
 
-							// 3. Layer any pending update on top of the snapshot.
+							// 3. A pending delete makes this doc invisible.
+							if (buffer.isDeleted(doc.ref.path)) return null;
+
+							// 4. Layer any pending update on top of the snapshot.
 							const staged = buffer.getByPath(doc.ref.path);
-							if (staged) return { ...staged.appData };
+							if (staged && staged.op !== "delete")
+								return { ...staged.appData };
 
 							const data = doc.data();
 							if (!data) return null;
 							return { id: doc.id, ...dbDataToAppData(data, mapper) };
+						},
+						findMany: async ({ model, where, limit, offset, sortBy }: any) => {
+							const col = getCollectionRef(db, model, collections);
+							const byPath = new Map<string, Record<string, any>>();
+
+							// 1. Real reads (chunked for oversized `in` clauses), overlaying
+							//    any staged update and dropping any staged delete.
+							for (const whereClause of getChunkedWhereClauses(where)) {
+								const q = applyWhereClause(col, whereClause, mapper);
+								const snap = await transaction.get(q);
+								for (const doc of snap.docs) {
+									if (buffer.isDeleted(doc.ref.path)) continue;
+									const staged = buffer.getByPath(doc.ref.path);
+									if (staged && staged.op !== "delete") {
+										byPath.set(doc.ref.path, { ...staged.appData });
+										continue;
+									}
+									const data = doc.data();
+									if (!data) continue;
+									byPath.set(doc.ref.path, {
+										id: doc.id,
+										...dbDataToAppData(data, mapper),
+									});
+								}
+							}
+
+							// 2. Overlay: staged creates in this transaction that match `where`.
+							for (const entry of buffer.values()) {
+								if (entry.op !== "create" || entry.model !== model) continue;
+								if (
+									!byPath.has(entry.ref.path) &&
+									matchesWhere(entry.appData, where)
+								) {
+									byPath.set(entry.ref.path, { ...entry.appData });
+								}
+							}
+
+							let results = Array.from(byPath.values());
+							if (sortBy?.field) {
+								results.sort((a, b) => {
+									const aVal = a[sortBy.field];
+									const bVal = b[sortBy.field];
+									const dir = sortBy.direction === "desc" ? -1 : 1;
+									if (aVal < bVal) return -1 * dir;
+									if (aVal > bVal) return 1 * dir;
+									return 0;
+								});
+							}
+							if (offset) results = results.slice(offset);
+							if (limit !== undefined) results = results.slice(0, limit);
+							return results;
+						},
+						deleteMany: async ({ model, where }: any) => {
+							const col = getCollectionRef(db, model, collections);
+							let count = 0;
+							const seenPaths = new Set<string>();
+							for (const whereClause of getChunkedWhereClauses(where)) {
+								const q = applyWhereClause(col, whereClause, mapper);
+								const snap = await transaction.get(q);
+								for (const doc of snap.docs) {
+									if (
+										seenPaths.has(doc.ref.path) ||
+										buffer.isDeleted(doc.ref.path)
+									)
+										continue;
+									seenPaths.add(doc.ref.path);
+									buffer.stageDelete(model, doc.ref);
+									count++;
+								}
+							}
+							return count;
+						},
+						consumeOne: async ({ model, where }: any) => {
+							const col = getCollectionRef(db, model, collections);
+							const stagedCreate = buffer.findCreateMatching(model, where);
+							if (stagedCreate) {
+								buffer.stageDelete(model, stagedCreate.ref);
+								return { ...stagedCreate.appData };
+							}
+							const doc = await lookupTxDoc(transaction, col, where, mapper);
+							if (!doc || buffer.isDeleted(doc.ref.path)) return null;
+							const staged = buffer.getByPath(doc.ref.path);
+							const appData =
+								staged && staged.op !== "delete"
+									? { ...staged.appData }
+									: (() => {
+											const data = doc.data();
+											return data
+												? { id: doc.id, ...dbDataToAppData(data, mapper) }
+												: null;
+										})();
+							if (!appData) return null;
+							buffer.stageDelete(model, doc.ref);
+							return appData;
 						},
 					};
 
@@ -1706,7 +1825,11 @@ export const firestoreAdapter: (
 						return matchingIds.size;
 					}
 
-					const q: FirebaseFirestore.Query = applyWhereClause(col, where, mapper);
+					const q: FirebaseFirestore.Query = applyWhereClause(
+						col,
+						where,
+						mapper,
+					);
 					const snap = await q.count().get();
 					return snap.data().count ?? 0;
 				},

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -413,9 +413,7 @@ describe("Transaction buffering (regression for #24)", () => {
 			});
 			return tx.findOne({
 				model: "user",
-				where: [
-					{ field: "email", operator: "eq", value: "tx3@example.com" },
-				],
+				where: [{ field: "email", operator: "eq", value: "tx3@example.com" }],
 			});
 		});
 		expect(observed).toBeTruthy();
@@ -533,5 +531,137 @@ describe("Transaction buffering (regression for #24)", () => {
 
 		const users = await db.collection(TX_COLLECTIONS.users).get();
 		expect(users.size).toBe(0);
+	});
+
+	// better-auth's magic-link plugin consumes a verification token inside
+	// adapter.transaction(), calling txAdapter.findMany (locate the latest
+	// token), txAdapter.consumeOne (read + delete atomically), and
+	// txAdapter.deleteMany (expired-token cleanup) — none of which the
+	// buffered tx adapter implemented, so every magic-link verify failed with
+	// "txAdapter.findMany is not a function". These tests exercise those
+	// three methods directly against the `user` model/collection (already
+	// covered above) to isolate the tx-adapter behavior from model-name
+	// resolution.
+	it("findMany inside a transaction returns matching Firestore-resident docs, sorted and limited", async () => {
+		const seedRef1 = db.collection(TX_COLLECTIONS.users).doc();
+		const seedRef2 = db.collection(TX_COLLECTIONS.users).doc();
+		await seedRef1.set({
+			email: "fm-shared@example.com",
+			name: "old",
+			createdAt: new Date("2030-01-01T00:00:00.000Z"),
+		});
+		await seedRef2.set({
+			email: "fm-shared@example.com",
+			name: "new",
+			createdAt: new Date("2030-01-02T00:00:00.000Z"),
+		});
+
+		const results = await adapter.transaction(async (tx: any) => {
+			return tx.findMany({
+				model: "user",
+				where: [
+					{ field: "email", operator: "eq", value: "fm-shared@example.com" },
+				],
+				sortBy: { field: "createdAt", direction: "desc" },
+				limit: 1,
+			});
+		});
+		expect(results).toHaveLength(1);
+		expect(results[0].name).toBe("new");
+	});
+
+	it("findMany inside a transaction overlays a create staged earlier in the same transaction", async () => {
+		const results = await adapter.transaction(async (tx: any) => {
+			await tx.create({
+				model: "user",
+				data: { email: "fm-buffered@example.com", name: "Buffered" },
+			});
+			return tx.findMany({
+				model: "user",
+				where: [
+					{ field: "email", operator: "eq", value: "fm-buffered@example.com" },
+				],
+			});
+		});
+		expect(results).toHaveLength(1);
+		expect(results[0].name).toBe("Buffered");
+	});
+
+	it("consumeOne inside a transaction returns the doc and deletes it on flush", async () => {
+		const seedRef = db.collection(TX_COLLECTIONS.users).doc();
+		await seedRef.set({ email: "consume@example.com", name: "ToConsume" });
+
+		const consumed = await adapter.transaction(async (tx: any) => {
+			return tx.consumeOne({
+				model: "user",
+				where: [
+					{ field: "email", operator: "eq", value: "consume@example.com" },
+				],
+			});
+		});
+		expect(consumed?.name).toBe("ToConsume");
+
+		const persisted = await seedRef.get();
+		expect(persisted.exists).toBe(false);
+	});
+
+	it("consumeOne inside a transaction is invisible to a subsequent findOne in the same transaction", async () => {
+		const seedRef = db.collection(TX_COLLECTIONS.users).doc();
+		await seedRef.set({ email: "gone@example.com", name: "Gone" });
+
+		const observedAfterConsume = await adapter.transaction(async (tx: any) => {
+			await tx.consumeOne({
+				model: "user",
+				where: [{ field: "email", operator: "eq", value: "gone@example.com" }],
+			});
+			return tx.findOne({
+				model: "user",
+				where: [{ field: "email", operator: "eq", value: "gone@example.com" }],
+			});
+		});
+		expect(observedAfterConsume).toBeNull();
+	});
+
+	it("deleteMany inside a transaction removes all matching docs on flush", async () => {
+		const seedRef1 = db.collection(TX_COLLECTIONS.users).doc();
+		const seedRef2 = db.collection(TX_COLLECTIONS.users).doc();
+		await seedRef1.set({ email: "expire@example.com", name: "a" });
+		await seedRef2.set({ email: "expire@example.com", name: "b" });
+
+		const count = await adapter.transaction(async (tx: any) => {
+			return tx.deleteMany({
+				model: "user",
+				where: [
+					{ field: "email", operator: "eq", value: "expire@example.com" },
+				],
+			});
+		});
+		expect(count).toBe(2);
+
+		const remaining = await db
+			.collection(TX_COLLECTIONS.users)
+			.where("email", "==", "expire@example.com")
+			.get();
+		expect(remaining.size).toBe(0);
+	});
+
+	it("throwing after consumeOne inside the callback aborts the transaction (doc survives)", async () => {
+		const seedRef = db.collection(TX_COLLECTIONS.users).doc();
+		await seedRef.set({ email: "abort@example.com", name: "Abort" });
+
+		await expect(
+			adapter.transaction(async (tx: any) => {
+				await tx.consumeOne({
+					model: "user",
+					where: [
+						{ field: "email", operator: "eq", value: "abort@example.com" },
+					],
+				});
+				throw new Error("intentional");
+			}),
+		).rejects.toThrow("intentional");
+
+		const persisted = await seedRef.get();
+		expect(persisted.exists).toBe(true);
 	});
 });


### PR DESCRIPTION
## The bug

PR #27 (closes #24) rewrote the transactional adapter with a buffered `TxBuffer` to fix Firestore's read-before-write ordering requirement, but the `txAdapter` object it builds inside `transaction()` only implements `create`, `update`, and `findOne`.

Better Auth's magic-link plugin consumes a verification token by calling `adapter.transaction()` and then, inside the callback, `txAdapter.findMany` (locate the latest token), `txAdapter.consumeOne` (read + delete atomically), and `txAdapter.deleteMany` (expired-token cleanup). None of these exist on the buffered `txAdapter`, so every magic-link verification throws:

```
TypeError: txAdapter.findMany is not a function
```

This is a regression from #27/#24 — magic-link sign-in worked before that rewrite (the old, unbuffered transaction wrapper apparently delegated to the full adapter), and broke silently afterward since the PR's test suite only covered the sign-up flow that #24 was about, not magic-link/verification.

## The fix

Extends `TxBuffer` and the `txAdapter` following the same pattern PR #27 established:

- **`findMany`**: reads via `transaction.get()` (chunked for oversized `in` clauses, like the non-tx path), overlays any staged update on top of each read doc, drops any doc with a staged delete, and additionally overlays matching staged creates from this same transaction — mirroring the existing `findOne`/`update` overlay logic. Supports `sortBy`/`limit`/`offset` like the non-tx `findMany`.
- **`deleteMany`**: stages deletes into the buffer rather than deleting immediately, consistent with how `create`/`update` already defer writes until `flush()`.
- **`consumeOne`**: read + stage-delete in one step, checking the buffer first for a matching staged create (mirrors `update`'s buffer-first lookup).
- **`TxBuffer.flush()`**: now handles the new `"delete"` op alongside `create`/`update`.
- **`findOne`**'s read overlay was also missing a check for staged deletes — it would return `{...staged.appData}` off of a delete entry (which has no `appData`) once one existed. Fixed as part of the same `TxBuffer` change, with `TxBufferEntry` now a discriminated union (`TxBufferWriteEntry | TxBufferDeleteEntry`) so this is caught at the type level going forward.

All reads still happen via `transaction.get()` before any `transaction.set`/`update`/`delete` — the read-before-write invariant from #27 is preserved; the new methods don't call `transaction.get()` after any write, and all actual Firestore writes (including deletes) remain confined to `flush()`, called once after the callback resolves.

## Tests

Added 6 tests to the existing `Transaction buffering (regression for #24)` block in `tests/index.test.ts`, run against the `user` model to isolate tx-adapter behavior from model-name resolution:

| Test | Covers |
|---|---|
| `findMany` inside a transaction returns matching Firestore-resident docs, sorted and limited | real-read path with `sortBy`/`limit` |
| `findMany` inside a transaction overlays a create staged earlier in the same transaction | buffered-create overlay |
| `consumeOne` inside a transaction returns the doc and deletes it on flush | read + deferred delete |
| `consumeOne` inside a transaction is invisible to a subsequent `findOne` in the same transaction | delete overlay on `findOne` |
| `deleteMany` inside a transaction removes all matching docs on flush | bulk deferred delete |
| throwing after `consumeOne` inside the callback aborts the transaction (doc survives) | rollback safety for the new delete op |

## Test results

```
Test Files  2 passed (2)
     Tests  29 passed (29)
```

23 from the existing suite + 6 new tests, all passing. Also ran `pnpm lint` and `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)