### PR TITLE
fix(adapter): complete tx adapter verification support

### DIFF
--- a/src/firebase-adapter.ts
+++ b/src/firebase-adapter.ts
@@ -160,7 +160,7 @@ function getCollectionRef(
 	if (normalized === "user") return db.collection(collections.users);
 	if (normalized === "session") return db.collection(collections.sessions);
 	if (normalized === "account") return db.collection(collections.accounts);
-	if (normalized === "verificationtoken")
+	if (normalized === "verification" || normalized === "verificationtoken")
 		return db.collection(collections.verificationTokens);
 	return db.collection(model);
 }
@@ -717,6 +717,9 @@ export const firestoreAdapter: (
 							if (!data) return null;
 							return { id: doc.id, ...dbDataToAppData(data, mapper) };
 						},
+						// Subset of the non-tx `findMany` path: no OR-split queries or
+						// direct `id` lookups. better-auth's tx callbacks (e.g.
+						// consumeVerificationValue) only issue simple equality filters.
 						findMany: async ({ model, where, limit, offset, sortBy }: any) => {
 							const col = getCollectionRef(db, model, collections);
 							const byPath = new Map<string, Record<string, any>>();
@@ -785,6 +788,19 @@ export const firestoreAdapter: (
 									buffer.stageDelete(model, doc.ref);
 									count++;
 								}
+							}
+							// Staged creates are invisible to Firestore queries until flush.
+							for (const entry of buffer.values()) {
+								if (entry.op !== "create" || entry.model !== model) continue;
+								if (
+									seenPaths.has(entry.ref.path) ||
+									buffer.isDeleted(entry.ref.path)
+								)
+									continue;
+								if (!matchesWhere(entry.appData, where)) continue;
+								seenPaths.add(entry.ref.path);
+								buffer.stageDelete(model, entry.ref);
+								count++;
 							}
 							return count;
 						},
@@ -1093,6 +1109,27 @@ export const firestoreAdapter: (
 						count++;
 					}
 					return count;
+				},
+				consumeOne: async <T>({
+					model,
+					where,
+				}: {
+					model: string;
+					where: WhereCondition[];
+				}) => {
+					const col = getCollectionRef(db, model, collections);
+					return await db.runTransaction(async (transaction) => {
+						const doc = await lookupTxDoc(transaction, col, where, mapper);
+						if (!doc) return null;
+						const data = doc.data();
+						if (!data) return null;
+						const appData = {
+							id: doc.id,
+							...dbDataToAppData(data, mapper),
+						};
+						transaction.delete(doc.ref);
+						return appData as T;
+					});
 				},
 				findOne: async ({ model, where, select }) => {
 					const col = getCollectionRef(db, model, collections);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -645,6 +645,93 @@ describe("Transaction buffering (regression for #24)", () => {
 		expect(remaining.size).toBe(0);
 	});
 
+	it("deleteMany inside a transaction removes buffered creates matching where", async () => {
+		const count = await adapter.transaction(async (tx: any) => {
+			await tx.create({
+				model: "user",
+				data: { email: "buffered-delete@example.com", name: "Buffered" },
+			});
+			return tx.deleteMany({
+				model: "user",
+				where: [
+					{
+						field: "email",
+						operator: "eq",
+						value: "buffered-delete@example.com",
+					},
+				],
+			});
+		});
+		expect(count).toBe(1);
+
+		const users = await db
+			.collection(TX_COLLECTIONS.users)
+			.where("email", "==", "buffered-delete@example.com")
+			.get();
+		expect(users.size).toBe(0);
+	});
+
+	it("consumeVerificationValue-style flow works on the verification model inside a transaction", async () => {
+		const identifier = "magic-link:test@example.com";
+		const oldRef = db.collection(TX_COLLECTIONS.verificationTokens).doc();
+		const newRef = db.collection(TX_COLLECTIONS.verificationTokens).doc();
+		await oldRef.set({
+			identifier,
+			token: "old-token",
+			expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+			createdAt: new Date("2030-01-01T00:00:00.000Z"),
+		});
+		await newRef.set({
+			identifier,
+			token: "new-token",
+			expiresAt: new Date("2030-01-02T00:00:00.000Z"),
+			createdAt: new Date("2030-01-02T00:00:00.000Z"),
+		});
+
+		const consumed = await adapter.transaction(async (tx: any) => {
+			const where = [
+				{ field: "identifier", operator: "eq", value: identifier },
+			];
+			const latest = (
+				await tx.findMany({
+					model: "verification",
+					where,
+					sortBy: { field: "createdAt", direction: "desc" },
+					limit: 1,
+				})
+			)[0];
+			expect(latest?.token).toBe("new-token");
+			const row = await tx.consumeOne({
+				model: "verification",
+				where: [{ field: "id", operator: "eq", value: latest.id }],
+			});
+			await tx.deleteMany({ model: "verification", where });
+			return row;
+		});
+
+		expect(consumed?.token).toBe("new-token");
+
+		const remaining = await db
+			.collection(TX_COLLECTIONS.verificationTokens)
+			.where("identifier", "==", identifier)
+			.get();
+		expect(remaining.size).toBe(0);
+	});
+
+	it("native consumeOne deletes a matching Firestore doc", async () => {
+		const seedRef = db.collection(TX_COLLECTIONS.users).doc();
+		await seedRef.set({ email: "native-consume@example.com", name: "Native" });
+
+		const consumed = await adapter.consumeOne({
+			model: "user",
+			where: [
+				{ field: "email", operator: "eq", value: "native-consume@example.com" },
+			],
+		});
+		expect(consumed?.name).toBe("Native");
+		expect((await seedRef.get()).exists).toBe(false);
+	});
+
 	it("throwing after consumeOne inside the callback aborts the transaction (doc survives)", async () => {
 		const seedRef = db.collection(TX_COLLECTIONS.users).doc();
 		await seedRef.set({ email: "abort@example.com", name: "Abort" });


### PR DESCRIPTION
## Summary

Maintainer polish stacked on #33 (already on `main` as a non-releasing `refactor:` merge).

- Map Better Auth's `verification` model to the configured `verificationTokens` collection
- Stage-delete buffered creates in tx `deleteMany`
- Document tx `findMany` as an intentional subset of the non-tx path
- Add native top-level `consumeOne` (`<T>` typed)
- Tests: buffered-create `deleteMany`, `consumeVerificationValue`-style verification flow, native `consumeOne`

## Related

- #33 — contributor tx adapter fix (merged)
- #34 — polish stacked PR (merged into this branch)

## Test plan

- [x] `FIRESTORE_EMULATOR_HOST=localhost:8080 pnpm vitest run -t "Transaction buffering"` — 17 passed
- [x] `pnpm lint` / `pnpm build`