### PR TITLE
docs(skills): adopt skills.sh layout and request indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,13 +482,15 @@ Better Auth verification token lookups require a Firestore query pattern that de
 
 ## AI Assistant Skill
 
-A `SKILL.md` is included at the root of this repo. It works with Cursor, Claude Code, Codex, Copilot, Windsurf, and [70+ other agents](https://skills.sh) via the skills.sh ecosystem.
+The agent skill lives at [`skills/firestore-better-auth/SKILL.md`](./skills/firestore-better-auth/SKILL.md). It works with Cursor, Claude Code, Codex, Copilot, Windsurf, and [70+ other agents](https://skills.sh) via the [skills.sh](https://skills.sh) ecosystem.
 
 The skill teaches AI assistants the correct setup, required Firestore index, environment variable handling, and common gotchas. It also triggers when you ask about using Firestore with Better Auth, migrating from Auth.js/NextAuth, or troubleshooting `FIREBASE_PRIVATE_KEY` issues.
 
 ```bash
 npx skills add yultyyev/better-auth-firestore
 ```
+
+Install works today from GitHub. The [skills.sh listing page](https://skills.sh/yultyyev/better-auth-firestore) and README badge appear once indexed — tracking [vercel-labs/skills#1601](https://github.com/vercel-labs/skills/issues/1601).
 
 ---
 

--- a/skills/firestore-better-auth/SKILL.md
+++ b/skills/firestore-better-auth/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: firestore-better-auth
+version: 1.0.0
 description: >-
   Use Firestore as the database adapter for Better Auth (Firebase Admin SDK).
   Use when storing Better Auth users, sessions, accounts, and verification


### PR DESCRIPTION
## Summary

Mirrors [better-auth-firebase-auth#25](https://github.com/yultyyev/better-auth-firebase-auth/pull/25):

- Move agent skill from root `SKILL.md` to `skills/firestore-better-auth/SKILL.md` so the skill `name` matches its directory (skills.sh / agent-skills convention)
- Add `version: 1.0.0` frontmatter for skills.sh metadata
- Update README AI Assistant Skill section with the new path and indexing status
- GitHub topics `agent-skills` and `ai-skills` added to the repo for discoverability
- Tracks skills.sh indexing via [vercel-labs/skills#1601](https://github.com/vercel-labs/skills/issues/1601)

## Test plan

- [ ] `npx skills add yultyyev/better-auth-firestore --list` discovers `firestore-better-auth`
- [ ] `npx skills add yultyyev/better-auth-firestore` installs successfully
- [ ] After skills.sh indexes the repo, verify https://skills.sh/yultyyev/better-auth-firestore and the README badge resolve