### PR TITLE
fix(adapter): sort filtered findMany queries in memory (drop composite-index requirement)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,13 +63,13 @@ firestoreAdapter({
 });
 ```
 
-## Required Firestore Index
+## Firestore Index (Optional)
 
-The adapter requires a composite index on the verification collection. Without it, `verificationToken` queries fail. Always remind users to create it when setting up a new project.
+No composite index is required. The adapter never issues a filter + `orderBy` query: `findMany` calls that combine a `where` filter with a `sortBy` apply the filter server-side and sort the results in memory. Verification-token lookups (`identifier ==` ordered by `createdAt desc`) therefore work with only Firestore's automatic single-field indexes.
 
-Fields: `identifier` (ASC), `createdAt` (DESC), `__name__` (DESC), scope: Collection.
+Older versions (< v1.1) required a composite index on the verification collection (`identifier` ASC, `createdAt` DESC, `__name__` DESC). If a user reports `9 FAILED_PRECONDITION: The query requires an index` (often surfaced by Better Auth as `Failed to parse state`), the fix is to upgrade — not to create the index.
 
-Helper: `generateIndexSetupUrl(projectId, databaseId?, collectionName?)` — generates the Firebase Console URL that pre-fills the index creation form.
+Helper (optional, for advanced/direct-query setups only): `generateIndexSetupUrl(projectId, databaseId?, collectionName?)` and `getIndexConfig(collectionName?)`. Both default `collectionName` to `verificationTokens` (use `verification_tokens` for snake_case).
 
 ## Important Constraints
 

--- a/README.md
+++ b/README.md
@@ -124,46 +124,13 @@ export const auth = betterAuth({
 3. Choose your preferred security rules mode (you can update rules later)
 4. Select a location for your database
 
-### 3. Create Required Firestore Index
+### 3. Firestore Index (Optional)
 
-The adapter requires a composite index on the `verification` collection. Choose one of the following methods:
+> **No composite index is required.** As of v1.1, the adapter sorts filtered queries — including verification-token lookups — in memory, so Firestore's automatic single-field indexes are sufficient. You can skip straight to the next step.
 
-**Option A: Create via Firebase Console (Recommended)**
+If you're upgrading from an earlier version that required a composite index on the verification collection (`identifier` ASC, `createdAt` DESC), you can safely leave that index in place or delete it — the adapter no longer depends on it.
 
-You can generate a direct link that pre-fills the index creation form:
-
-```ts
-import { generateIndexSetupUrl } from "better-auth-firestore";
-
-// Generate the URL (pre-fills the form automatically)
-const url = generateIndexSetupUrl(
-  process.env.FIREBASE_PROJECT_ID!,
-  "(default)", // or your database ID if using a named database
-  "verification" // or your custom collection name
-);
-
-console.log("Open this URL to create the index:", url);
-```
-
-Or manually:
-1. Open: `https://console.firebase.google.com/project/YOUR_PROJECT_ID/firestore/indexes`
-2. Click "Create Index"
-3. Configure:
-   - **Collection ID:** `verification`
-   - **Fields:**
-     - `identifier` (Ascending)
-     - `createdAt` (Descending)
-     - `__name__` (Descending)
-   - **Query scope:** Collection
-4. Click "Create" and wait for the index to build (usually a few minutes)
-
-**Option B: Use firestore.indexes.json Template**
-
-1. Copy `firestore.indexes.json` from `node_modules/better-auth-firestore/` to your project root
-2. (Optional) Update collection name if using custom `collections.verificationTokens`
-3. Deploy: `firebase deploy --only firestore:indexes`
-
-> **Note:** If you're using a custom collection name for verification tokens (via `collections.verificationTokens`), replace `verification` with your custom collection name in the index configuration.
+The `generateIndexSetupUrl` / `getIndexConfig` helpers and the bundled `firestore.indexes.json` are still exported for advanced setups (for example, if you run your own `where` + `orderBy` queries directly against the verification collection outside the adapter). They default to the `verificationTokens` collection; pass `"verification_tokens"` when using the snake_case naming strategy, or your custom collection name.
 
 ### 4. Generate Service Account Key
 
@@ -257,7 +224,7 @@ The adapter maintains the same data shape as Auth.js/NextAuth for seamless migra
 
 > **Defaults:** Collections default to `users`, `sessions`, `accounts`, `verification_tokens` (snake_case) / `verificationTokens` (default). See [Options](#options) to customize collection names.
 >
-> **Note:** The `verification` collection requires a composite index on `identifier` (ASC), `createdAt` (DESC), `__name__` (DESC). See [Firebase Setup - Step 3](#3-create-required-firestore-index) for setup instructions.
+> **Note:** No composite index is required. Verification-token lookups are sorted in memory. See [Firebase Setup - Step 3](#3-firestore-index-optional) for details.
 
 ### Minimal Firestore Security Rules (server/admin only)
 
@@ -452,20 +419,18 @@ See also the [AI Assistant Skill](#ai-assistant-skill) — agents use it to avoi
 
 **Fix:** Use the Firestore Emulator and set `FIRESTORE_EMULATOR_HOST=localhost:8080` before running your app. See [Using the Firestore Emulator](#using-the-firestore-emulator) for setup instructions. The [AI Assistant Skill](#ai-assistant-skill) includes emulator commands for agents.
 
-### Error: Missing or insufficient permissions / Index required
+### Error: `9 FAILED_PRECONDITION: The query requires an index`
 
-**Symptom:** Queries on verification tokens fail with errors about missing index or insufficient permissions.
+**Symptom:** Queries on verification tokens fail with a `FAILED_PRECONDITION` / "The query requires an index" error (often surfaced by Better Auth as `Failed to parse state`).
 
-**Fix:** Create the required composite index on the `verification` collection. See [Firebase Setup - Step 3](#3-create-required-firestore-index) for detailed instructions.
+**Fix:** Upgrade to `better-auth-firestore` v1.1 or later. Older versions issued a `where` + `orderBy` query that required a composite index; the adapter now sorts filtered queries in memory, so no index is needed. After upgrading, the error disappears and any previously created composite index can be removed.
 
-You can generate a direct link using:
+If you cannot upgrade immediately, create the index from the URL in the error message, or generate it with:
 ```ts
 import { generateIndexSetupUrl } from "better-auth-firestore";
 const url = generateIndexSetupUrl(process.env.FIREBASE_PROJECT_ID!);
 console.log(url); // Open this URL to create the index
 ```
-
-The [AI Assistant Skill](#ai-assistant-skill) documents index fields and `generateIndexSetupUrl` for agent-driven setup.
 
 ## FAQ
 
@@ -481,15 +446,15 @@ Yes. `better-auth-firestore` is designed as a drop-in replacement for the Auth.j
 
 This package supports any server-side Node.js runtime: Next.js on Vercel (the default serverless runtime), Cloud Functions, Cloud Run, and standalone Node.js. The only restriction is the Edge Runtime — if you explicitly set `export const runtime = 'edge'` on a route, the Firebase Admin SDK will not load. Standard Vercel deployments are fully supported. See [Runtime compatibility](#runtime-compatibility) for the full matrix. Agents should follow the runtime table in the [AI Assistant Skill](#ai-assistant-skill).
 
-### Why is a Firestore composite index required for verification tokens?
+### Do I need a Firestore composite index for verification tokens?
 
-Better Auth verification token lookups require a Firestore query pattern that depends on a composite index. Without that index, verification-related queries can fail with a missing index error or insufficient permissions message. See [Create Required Firestore Index](#3-create-required-firestore-index) for the exact fields and setup options. The [AI Assistant Skill](#ai-assistant-skill) documents index creation and `generateIndexSetupUrl`.
+No. Better Auth's verification-token lookup filters by `identifier` and orders by `createdAt`, which historically required a composite index. As of v1.1 the adapter applies the filter server-side and sorts the (small, per-identifier) result set in memory, so no composite index is required. See [Firestore Index (Optional)](#3-firestore-index-optional) for the optional tooling that remains available.
 
 ## AI Assistant Skill
 
 The agent skill lives at [`skills/firestore-better-auth/SKILL.md`](./skills/firestore-better-auth/SKILL.md). It works with Cursor, Claude Code, Codex, Copilot, Windsurf, and [70+ other agents](https://skills.sh) via the [skills.sh](https://skills.sh) ecosystem.
 
-The skill teaches AI assistants the correct setup, required Firestore index, environment variable handling, and common gotchas. It also triggers when you ask about using Firestore with Better Auth, migrating from Auth.js/NextAuth, or troubleshooting `FIREBASE_PRIVATE_KEY` issues.
+The skill teaches AI assistants the correct setup, environment variable handling, and common gotchas. It also triggers when you ask about using Firestore with Better Auth, migrating from Auth.js/NextAuth, or troubleshooting `FIREBASE_PRIVATE_KEY` issues.
 
 ```bash
 npx skills add yultyyev/better-auth-firestore
@@ -515,6 +480,10 @@ Install works today from GitHub. The [skills.sh listing page](https://skills.sh/
 ```bash
 pnpm build
 ```
+
+## Reporting issues
+
+Found a bug? First make sure you're on the latest version, then [open an issue](https://github.com/yultyyev/better-auth-firestore/issues) with the package version and a minimal repro. Please redact secrets and PII (Firebase project IDs, `FIREBASE_PRIVATE_KEY`, tokens, and `create_composite` index URLs).
 
 ## Contributing
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,7 +1,7 @@
 {
   "indexes": [
     {
-      "collectionGroup": "verification",
+      "collectionGroup": "verificationTokens",
       "queryScope": "COLLECTION",
       "fields": [
         {

--- a/llms.txt
+++ b/llms.txt
@@ -26,7 +26,7 @@ This package stores Better Auth users, sessions, accounts, and verification toke
 
 ## Key topics for AI assistants
 
-- Required Firestore composite index on `verification`: `identifier` ASC, `createdAt` DESC, `__name__` DESC — use `generateIndexSetupUrl(projectId)` from this package
+- No Firestore composite index required (v1.1+): the adapter applies `where` filters server-side and sorts in memory, so verification-token lookups (`identifier ==` ordered by `createdAt desc`) need only automatic single-field indexes. A `9 FAILED_PRECONDITION: The query requires an index` error means the project is on an older version — upgrade rather than creating the index. `generateIndexSetupUrl(projectId)` / `getIndexConfig()` remain as optional helpers.
 - `FIREBASE_PRIVATE_KEY` env vars often contain literal `\n` — call `.replace(/\\n/g, "\n")` before passing to `cert()`
 - Node.js runtimes only — Firebase Admin SDK does not run on Vercel Edge or Cloudflare Workers (default Vercel serverless Node.js is supported)
 - Migration from Auth.js/NextAuth: same default collection names and field shapes, no Firestore data migration needed

--- a/skills/firestore-better-auth/SKILL.md
+++ b/skills/firestore-better-auth/SKILL.md
@@ -89,32 +89,13 @@ export const auth = betterAuth({
 
 ---
 
-## Required Firestore composite index
+## Firestore composite index — not required (v1.1+)
 
-The adapter requires a composite index on the `verification` collection for token lookups. Without it, Better Auth sign-in verification will fail.
+No composite index is required. The adapter never combines a `where` filter with a Firestore `orderBy`: it applies the filter server-side and sorts the results in memory. Verification-token lookups (`identifier ==` ordered by `createdAt desc`) work with Firestore's automatic single-field indexes alone.
 
-**Quick setup — generate the Firebase Console URL:**
+**If sign-in fails with `9 FAILED_PRECONDITION: The query requires an index`** (Better Auth may surface this as `Failed to parse state`), you are on an older version. **Upgrade to v1.1 or later** — do not create the index. Any composite index created for a previous version can be removed afterward.
 
-```ts
-import { generateIndexSetupUrl } from "better-auth-firestore";
-const url = generateIndexSetupUrl(process.env.FIREBASE_PROJECT_ID!);
-console.log(url); // Open to auto-fill the index form
-```
-
-**Or deploy via CLI:**
-
-Copy `firestore.indexes.json` from `node_modules/better-auth-firestore/` to your project root, then:
-
-```bash
-firebase deploy --only firestore:indexes
-```
-
-**Index fields:**
-- Collection: `verification`
-- `identifier` (Ascending)
-- `createdAt` (Descending)
-- `__name__` (Descending)
-- Query scope: Collection
+**Optional tooling** (only for advanced setups that query the verification collection directly, outside the adapter): `generateIndexSetupUrl(projectId, databaseId?, collectionName?)` and `getIndexConfig(collectionName?)`, plus the bundled `firestore.indexes.json`. These default to the `verificationTokens` collection (use `verification_tokens` for the snake_case strategy).
 
 ---
 
@@ -204,7 +185,19 @@ No credentials or service account needed when using the emulator.
 
 ## Common mistakes
 
-- **Missing Firestore composite index** — Verification token queries fail with "index required" or "insufficient permissions". Run `generateIndexSetupUrl` to get the setup link.
+- **`The query requires an index` on verification tokens** — You're on a version older than v1.1. Upgrade `better-auth-firestore`; the adapter now sorts filtered queries in memory and needs no composite index.
 - **FIREBASE_PRIVATE_KEY with literal `\n`** — Always call `.replace(/\\n/g, "\n")` on the key before passing to `cert()`.
 - **Using at edge runtime** — Firebase Admin SDK does not run on Vercel Edge or Cloudflare Workers. Use Node.js runtimes only.
 - **Deprecated scoped package** — Use `better-auth-firestore` (unscoped). The `@yultyyev/better-auth-firestore` package is deprecated.
+
+---
+
+## Reporting issues
+
+If behavior still looks like a library bug after checking the mistakes above:
+
+1. First confirm the project is on the **latest version** — many reports (e.g. the composite-index error) are already fixed.
+2. Only file an issue when the **user explicitly asks** — never open one autonomously.
+3. **Redact secrets and PII** before filing: Firebase project IDs, `FIREBASE_PRIVATE_KEY`, tokens, and any `create_composite` index URL (it encodes the project path). Include the package version and a minimal repro instead.
+
+Issues: https://github.com/yultyyev/better-auth-firestore/issues

--- a/src/firebase-adapter.ts
+++ b/src/firebase-adapter.ts
@@ -1510,15 +1510,9 @@ export const firestoreAdapter: (
 						// Fetch results for each OR group
 						const allResultsMap = new Map<string, any>();
 						for (const group of orGroups) {
-							let q = applyWhereClause(col, group, mapper);
-
-							// Apply sorting before fetching
-							if (sortBy?.field) {
-								const fieldName = mapper.toDb(sortBy.field);
-								const direction = sortBy.direction === "desc" ? "desc" : "asc";
-								q = q.orderBy(fieldName, direction);
-							}
-
+							// Results are merged and sorted in memory below, so we skip
+							// Firestore's orderBy to avoid composite-index requirements.
+							const q = applyWhereClause(col, group, mapper);
 							const snap = await q.get();
 							snap.docs.forEach((d) => {
 								const data = d.data();
@@ -1620,16 +1614,13 @@ export const firestoreAdapter: (
 									? { ...w, value: chunk as WhereCondition["value"] }
 									: w,
 							);
-							let cq: FirebaseFirestore.Query = applyWhereClause(
+							// Results are merged and sorted in memory below, so we skip
+							// Firestore's orderBy to avoid composite-index requirements.
+							const cq: FirebaseFirestore.Query = applyWhereClause(
 								col,
 								chunkedWhere,
 								mapper,
 							);
-							if (sortBy?.field) {
-								const fieldName = mapper.toDb(sortBy.field);
-								const direction = sortBy.direction === "desc" ? "desc" : "asc";
-								cq = cq.orderBy(fieldName, direction);
-							}
 							const csnap = await cq.get();
 							for (const d of csnap.docs) {
 								const data = d.data();
@@ -1692,12 +1683,8 @@ export const firestoreAdapter: (
 							q = applyWhereClause(col, whereWithoutContains, mapper);
 						}
 
-						if (sortBy?.field) {
-							const fieldName = mapper.toDb(sortBy.field);
-							const direction = sortBy.direction === "desc" ? "desc" : "asc";
-							q = q.orderBy(fieldName, direction);
-						}
-
+						// Results are filtered and sorted in memory below, so we skip
+						// Firestore's orderBy to avoid composite-index requirements.
 						const snap = await q.get();
 						let results = snap.docs.map((d) => {
 							const data = d.data();
@@ -1758,8 +1745,43 @@ export const firestoreAdapter: (
 						return results as any[];
 					}
 
-					// No client-side filtering needed - use Firestore offset/limit directly
-					// Firestore requires orderBy before using offset
+					// No client-side filtering needed.
+					//
+					// When a query pairs a `where` filter with a `sortBy` on a
+					// different field, Firestore demands a composite index — this is
+					// exactly the verification-token lookup better-auth performs
+					// (`identifier ==` ordered by `createdAt desc`). Instead of
+					// forcing every consumer to provision that index, we let
+					// Firestore apply the filter server-side (covered by automatic
+					// single-field indexes) and sort the already-narrowed matches in
+					// memory. This mirrors the transaction `findMany` path.
+					const hasWhereFilter = !!(where && where.length > 0);
+					if (sortBy?.field && hasWhereFilter) {
+						const filteredSnap = await q.get();
+						let ordered = filteredSnap.docs.map((d) => {
+							const data = d.data();
+							const result: any = { id: d.id };
+							for (const [k, v] of Object.entries(data)) {
+								result[mapper.fromDb(k)] = convertTimestamp(v);
+							}
+							return result;
+						});
+						ordered.sort((a: any, b: any) => {
+							const aVal = a[sortBy.field];
+							const bVal = b[sortBy.field];
+							const dir = sortBy.direction === "desc" ? -1 : 1;
+							if (aVal < bVal) return -1 * dir;
+							if (aVal > bVal) return 1 * dir;
+							return 0;
+						});
+						if (offset) ordered = ordered.slice(offset);
+						if (limit) ordered = ordered.slice(0, limit);
+						return ordered as any[];
+					}
+
+					// No filter (or no sort): a lone `orderBy`/offset is served by an
+					// automatic single-field index, so Firestore can page natively.
+					// Firestore requires orderBy before using offset.
 					if (offset && !sortBy?.field) {
 						// If offset is provided but no sortBy, order by document ID for consistent results
 						q = q.orderBy(FieldPath.documentId());

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,17 +1,23 @@
 /**
- * Generate a Firebase Console URL for creating the required Firestore composite index.
- * This URL will pre-fill the index creation form with the correct configuration,
- * similar to the URLs provided in Firestore error messages.
+ * Generate a Firebase Console URL for creating a Firestore composite index on
+ * the verification collection.
+ *
+ * NOTE: As of v1.1, this index is **optional**. The adapter no longer issues
+ * the filter + `orderBy` query shape that requires a composite index — filtered
+ * queries are sorted in memory instead. This helper is kept for consumers who
+ * still want the index for performance on very large verification collections.
  *
  * @param projectId - Your Firebase project ID
  * @param databaseId - Your Firestore database ID (defaults to "(default)")
- * @param collectionName - The collection name (defaults to "verification")
+ * @param collectionName - The verification collection name. Defaults to
+ *   "verificationTokens" (the adapter's default). Pass "verification_tokens"
+ *   for the snake_case naming strategy, or your custom collection name.
  * @returns A Firebase Console URL with pre-filled index configuration
  */
 export function generateIndexSetupUrl(
 	projectId: string,
 	databaseId: string = "(default)",
-	collectionName: string = "verification",
+	collectionName: string = "verificationTokens",
 ): string {
 	// For protobuf, use the original format (keep (default) as-is)
 	const protobufDatabaseId = databaseId;
@@ -79,9 +85,13 @@ export function generateIndexSetupUrl(
 
 /**
  * Get the index configuration object for the verification collection.
- * This can be used to create firestore.indexes.json file.
+ * This can be used to create a firestore.indexes.json file.
+ *
+ * As of v1.1 this index is optional (see {@link generateIndexSetupUrl}).
+ * Defaults to "verificationTokens" to match the adapter's default collection
+ * name; pass "verification_tokens" for the snake_case strategy.
  */
-export function getIndexConfig(collectionName: string = "verification") {
+export function getIndexConfig(collectionName: string = "verificationTokens") {
 	return {
 		indexes: [
 			{

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -142,6 +142,63 @@ describe.each<TestConfig>(
 		expect(remaining[0]?.id).toBe(createdB.id);
 	});
 
+	// Regression: verification-token lookups issue `where identifier ==` +
+	// `sortBy createdAt desc`. That combination used to call Firestore's
+	// `orderBy` on a filtered query, which requires a composite index and fails
+	// in production with `9 FAILED_PRECONDITION: The query requires an index`.
+	// The adapter now sorts filtered queries in memory, so no index is needed.
+	it("findMany sorts a where-filtered query in memory (verification-token shape)", async () => {
+		const adapter = getAdapter() as any;
+		const col = cfg.collections.verificationTokens;
+		await clearCollection(db, col);
+		const identifier = "magic-link:index-regression@example.com";
+
+		// Seed directly with fixed ids so we can assert ordering by id.
+		// (adapter.create would route through Better Auth's schema, generate its
+		// own ids, and drop non-schema fields — this test targets the adapter's
+		// findMany query/sort path, not create transformation.)
+		await db.collection(col).doc("vt_old").set({
+			identifier,
+			value: "old-token",
+			createdAt: new Date("2030-01-01T00:00:00.000Z"),
+			expiresAt: new Date("2030-01-01T01:00:00.000Z"),
+		});
+		await db.collection(col).doc("vt_new").set({
+			identifier,
+			value: "new-token",
+			createdAt: new Date("2030-01-02T00:00:00.000Z"),
+			expiresAt: new Date("2030-01-02T01:00:00.000Z"),
+		});
+
+		const latest = await adapter.findMany({
+			model: "verification",
+			where: [{ field: "identifier", operator: "eq", value: identifier }],
+			sortBy: { field: "createdAt", direction: "desc" },
+			limit: 1,
+		});
+		expect(latest).toHaveLength(1);
+		expect(latest[0]?.id).toBe("vt_new");
+		expect(latest[0]?.value).toBe("new-token");
+
+		const ascending = await adapter.findMany({
+			model: "verification",
+			where: [{ field: "identifier", operator: "eq", value: identifier }],
+			sortBy: { field: "createdAt", direction: "asc" },
+		});
+		expect(ascending.map((r: any) => r.id)).toEqual(["vt_old", "vt_new"]);
+
+		const offsetResult = await adapter.findMany({
+			model: "verification",
+			where: [{ field: "identifier", operator: "eq", value: identifier }],
+			sortBy: { field: "createdAt", direction: "desc" },
+			offset: 1,
+		});
+		expect(offsetResult).toHaveLength(1);
+		expect(offsetResult[0]?.id).toBe("vt_old");
+
+		await clearCollection(db, col);
+	});
+
 	it("handles oversized non-ID in clauses across CRUD methods", async () => {
 		const adapter = getAdapter() as any;
 		const oversizedEmails = Array.from(


### PR DESCRIPTION
## Summary

Fixes the Firestore composite-index requirement that broke verification-token lookups in production. Better Auth's verification lookup issues `where identifier ==` + `sortBy createdAt desc`, which forced a composite index and failed with `9 FAILED_PRECONDITION: The query requires an index` (surfaced by Better Auth as `Failed to parse state`).

- The non-transaction `findMany` now applies the `where` filter server-side and **sorts the narrowed results in memory** whenever a filter is combined with a sort, mirroring the transaction path. No composite index is required.
- Unfiltered sorted queries still use Firestore's native ordering (served by an automatic single-field index).
- Removes the redundant Firestore `orderBy` from the OR / oversized-`IN` / client-side-filter paths, which already re-sorted in memory.
- Corrects the index-tooling default collection name (`verification` → `verificationTokens`) in `setup.ts` and `firestore.indexes.json`.
- Updates docs (README, AGENTS, SKILL, llms.txt) to note the index is no longer required and reframe the tooling as optional.
- Adds a short, guarded **Reporting issues** section (redact secrets/PII; report only on explicit user request).

## Behavioral notes / risk

- No regressions in the suite (**34/34** against the Firestore emulator).
- `Firestore .orderBy(field)` implicitly excludes documents missing that field; in-memory sorting includes them. Better Auth always sets `createdAt` on its models, so no practical impact.
- Filtered + sorted queries now fetch matches before applying `limit` in memory — fine for the naturally bounded auth collections (few tokens per identifier, few sessions per user); the query already failed in prod without the index.
- The emulator does **not** enforce composite indexes, so the added test validates in-memory sort/limit/offset correctness but cannot reproduce the production index error itself.

## Test plan

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm test` (vitest against the emulator) — 34/34
- [ ] Manual: verify sign-in / magic-link verification against **real** Firestore with no composite index present